### PR TITLE
[Feat/#36] 프로필 정보 수정 API 연동

### DIFF
--- a/src/components/common/ProfileCard.tsx
+++ b/src/components/common/ProfileCard.tsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router';
 import { Badge } from '../ui/badge';
 import { Card } from '../ui/card';
 import { SettingsModal } from './SettingsModal';
+import { updateProfile } from '../../api/member';
+import { fieldToJobType, stacksToEnumList } from '../../utils/stackMapping';
 
 interface ProfileCardProps {
   profileImage: string;
@@ -28,10 +30,33 @@ export function ProfileCard({
     commentNotificationsEnabled: true,
   });
 
-  const handleSaveSettings = (data: typeof profileData) => {
-    setProfileData(data);
-    // 실제 앱에서는 백엔드/상태 관리에 저장해야 함
-    console.log('설정 저장:', data);
+  const handleSaveSettings = async (data: typeof profileData) => {
+    try {
+      const jobType = fieldToJobType(data.techStack);
+      if (!jobType) {
+        alert('희망분야 값이 올바르지 않습니다.');
+        return;
+      }
+      
+      const techStackList = stacksToEnumList(data.preferredStacks);
+      
+      const response = await updateProfile({
+        nickname: data.nickname,
+        jobType,
+        techStackList,
+      });
+      
+      if (response.isSuccess) {
+        setProfileData(data);
+        alert('프로필이 성공적으로 수정되었습니다.');
+      } else {
+        alert(response.message || '프로필 수정에 실패했습니다.');
+      }
+    } catch (error: any) {
+      const errorMessage = error.response?.data?.message || '프로필 수정 중 오류가 발생했습니다.';
+      alert(errorMessage);
+      console.error('프로필 수정 실패:', error);
+    }
   };
 
   return (

--- a/src/components/common/SettingsModal.tsx
+++ b/src/components/common/SettingsModal.tsx
@@ -30,7 +30,7 @@ export function SettingsModal({ isOpen, onClose, currentProfile, onSave }: Setti
   const [profileImage, setProfileImage] = useState(currentProfile.profileImage);
   const [techStack, setTechStack] = useState(currentProfile.techStack);
   const [preferredStacks, setPreferredStacks] = useState<string[]>(currentProfile.preferredStacks || []);
-  const [notificationsEnabled, setNotificationsEnabled] = useState(currentProfile.notificationsEnabled);
+  const [notificationsEnabled] = useState(currentProfile.notificationsEnabled);
   const [commentNotificationsEnabled, setCommentNotificationsEnabled] = useState(currentProfile.commentNotificationsEnabled);
   const [nicknameChecked, setNicknameChecked] = useState(false);
 

--- a/src/utils/stackMapping.ts
+++ b/src/utils/stackMapping.ts
@@ -5,7 +5,9 @@ export const fieldToJobType = (field: string | null): JobType | null => {
   if (!field) return null;
   const map: Record<string, JobType> = {
     프론트: 'FRONTEND',
+    frontend: 'FRONTEND',
     백엔드: 'BACKEND',
+    backend: 'BACKEND',
     AI: 'AI',
   };
   return map[field] || null;


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #36

## 📌 feat: 프로필 정보 수정 API 연동
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
1. **ProfileCard 컴포넌트 API 연동**
   - [handleSaveSettings](cci:1://file:///c:/Users/kyueu_lz/Desktop/%EA%B9%83%ED%84%B84/git-turl-frontend/src/components/common/ProfileCard.tsx:32:2-36:4) 함수에서 실제 [updateProfile](cci:1://file:///c:/Users/kyueu_lz/Desktop/%EA%B9%83%ED%84%B84/git-turl-frontend/src/api/member.ts:53:0-65:2) API 호출하도록 수정
   - [fieldToJobType](cci:1://file:///c:/Users/kyueu_lz/Desktop/%EA%B9%83%ED%84%B84/git-turl-frontend/src/utils/stackMapping.ts:2:0-13:2)와 [stacksToEnumList](cci:1://file:///c:/Users/kyueu_lz/Desktop/%EA%B9%83%ED%84%B84/git-turl-frontend/src/utils/stackMapping.ts:35:0-40:2) 유틸리티 함수로 데이터 변환
   - 성공/실패 시 사용자 피드백 추가

2. **코드 정리**
   - SettingsModal에서 사용하지 않는 `setNotificationsEnabled` 변수 제거
   - stackMapping 유틸리티에 `frontend`, `backend` 매핑 추가

3. **API 명세서 준수**
   - PATCH 메서드 사용
   - 선택적 필드 구조에 맞는 요청 형식


## ✅ 테스트 결과
- 프로필 수정 시 실제 API로 데이터 전송 확인
- 새로고침 후에도 수정 내용 유지 확인
- 닉네임, 분야, 기술 스택 수정 정상 작동

## 📝 변경사항
- [src/components/common/ProfileCard.tsx](cci:7://file:///c:/Users/kyueu_lz/Desktop/%EA%B9%83%ED%84%B84/git-turl-frontend/src/components/common/ProfileCard.tsx:0:0-0:0): API 연동 로직 추가
- [src/components/common/SettingsModal.tsx](cci:7://file:///c:/Users/kyueu_lz/Desktop/%EA%B9%83%ED%84%B84/git-turl-frontend/src/components/common/SettingsModal.tsx:0:0-0:0): 미사용 변수 제거  
- [src/utils/stackMapping.ts](cci:7://file:///c:/Users/kyueu_lz/Desktop/%EA%B9%83%ED%84%B84/git-turl-frontend/src/utils/stackMapping.ts:0:0-0:0): 매핑 확장
 
## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->





