### PR TITLE
[Feat/#43] 마이페이지 GitHubCard 실제 프로필 데이터 연동

### DIFF
--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -84,8 +84,8 @@ export function MyPage() {
   }
 
   const githubData = {
-    username: 'developer_kim',
-    githubUrl: 'https://github.com/developer_kim',
+    username: profileData.githubId,
+    githubUrl: `https://github.com/${profileData.githubId}`,
   };
 
   // API에서 받은 레포지토리 데이터를 SummaryCarousel 형식으로 변환


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #43

## 📌 [Feat/#43] 마이페이지 GitHubCard 실제 프로필 데이터 연동
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
- 
- 
- 
<img width="2356" height="1226" alt="image" src="https://github.com/user-attachments/assets/314dfd6f-9484-46cb-a2ea-1b86de8ec8d5" />


## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
