### PR TITLE
[Feat/#40] 분석본 목록 조회 API 연동

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -156,6 +156,29 @@ export type ReportDetail = {
   content: Content | null;
 };
 
+// 분석본 목록 조회 타입
+export type ReportListItem = {
+  reportId: number;
+  reopName: string | null;
+  description: string | null;
+  createdAt: string;
+};
+
+export type ReportListResponse = {
+  data: ReportListItem[];
+  nextCursor: string;
+  hasNext: boolean;
+  pageSize: number;
+};
+
+export type ReportListParams = {
+  cursor?: string;
+  pageSize?: number;
+  startDate?: string;
+  endDate?: string;
+  status?: 'PUBLIC' | 'PRIVATE';
+};
+
 // ========== API 호출 함수 ==========
 
 /**
@@ -267,5 +290,28 @@ export const getReportDetail = async (
   const response = await client.get<ApiResponse<ReportDetail>>(
     `/api/v1/reports/${reportId}`
   );
+  return response.data;
+};
+
+/**
+ * 분석본 목록 조회
+ * GET /api/v1/reports
+ */
+export const getReportList = async (
+  params?: ReportListParams
+): Promise<ApiResponse<ReportListResponse>> => {
+  const queryParams = new URLSearchParams();
+  
+  if (params?.cursor) queryParams.append('cursor', params.cursor);
+  if (params?.pageSize) queryParams.append('pageSize', params.pageSize.toString());
+  if (params?.startDate) queryParams.append('startDate', params.startDate);
+  if (params?.endDate) queryParams.append('endDate', params.endDate);
+  if (params?.status) queryParams.append('status', params.status);
+
+  const url = queryParams.toString() 
+    ? `/api/v1/reports?${queryParams.toString()}`
+    : '/api/v1/reports';
+
+  const response = await client.get<ApiResponse<ReportListResponse>>(url);
   return response.data;
 };

--- a/src/pages/Analysis/Analytics.tsx
+++ b/src/pages/Analysis/Analytics.tsx
@@ -1,87 +1,47 @@
-import { useState } from 'react';
-import { Plus, Calendar, TrendingUp, FileText } from 'lucide-react';
-import { Link, useNavigate } from 'react-router';
+import { useState, useEffect } from 'react';
+import { Plus, Calendar } from 'lucide-react';
+import { useNavigate } from 'react-router';
 import { Card } from '../../components/ui/card';
-import { Badge } from '../../components/ui/badge';
-
-interface RepositoryAnalysis {
-  id: string;
-  repoName: string;
-  description: string;
-  createdAt: string;
-  isPublic: boolean;
-}
+import { getReportList, type ReportListItem, type ReportListParams } from '../../api/member';
 
 export function Analytics() {
   const navigate = useNavigate();
   const [filterMode, setFilterMode] = useState<'all' | 'date'>('all');
   const [startDate, setStartDate] = useState<string>('');
   const [endDate, setEndDate] = useState<string>('');
+  const [reports, setReports] = useState<ReportListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [hasNext, setHasNext] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string>('');
 
-  // Mock 데이터
-  const analyses: RepositoryAnalysis[] = [
-    {
-      id: '1',
-      repoName: '쇼핑몰-클론코딩',
-      description: 'React + Node.js로 간단한 쇼핑몰 기능 구현 (로그인, 장바구니, 결제 흐름 연습)',
-      createdAt: '2026-03-15',
-      isPublic: true,
-    },
-    {
-      id: '2',
-      repoName: '리액트-렌더링-최적화',
-      description: '불필요한 리렌더링 줄이기 위한 memo, useCallback 실습',
-      createdAt: '2026-03-10',
-      isPublic: false,
-    },
-    {
-      id: '3',
-      repoName: 'graphql-연습',
-      description: 'Apollo Server로 간단한 GraphQL API 구성해보기',
-      createdAt: '2026-03-05',
-      isPublic: true,
-    },
-    {
-      id: '4',
-      repoName: 'docker-배포-연습',
-      description: 'Docker로 Node 서버 컨테이너화하고 EC2에 배포 연습',
-      createdAt: '2026-03-01',
-      isPublic: false,
-    },
-    {
-      id: '5',
-      repoName: '간단-추천모델',
-      description: 'Python으로 영화 추천 로직 간단히 구현 (협업 필터링 기초)',
-      createdAt: '2026-02-28',
-      isPublic: true,
-    },
-    {
-      id: '6',
-      repoName: '채팅앱-토이프로젝트',
-      description: 'Socket.io로 실시간 채팅 기능 구현해보기',
-      createdAt: '2026-02-25',
-      isPublic: true,
-    },
-  ];
-
-  const filteredAnalyses = filterMode === 'all'
-    ? analyses
-    : analyses.filter((analysis) => {
-      if (!startDate && !endDate) return true;
-
-      const analysisDate = new Date(analysis.createdAt);
-      const start = startDate ? new Date(startDate) : null;
-      const end = endDate ? new Date(endDate) : null;
-
-      if (start && end) {
-        return analysisDate >= start && analysisDate <= end;
-      } else if (start) {
-        return analysisDate >= start;
-      } else if (end) {
-        return analysisDate <= end;
+  const fetchReports = async () => {
+    try {
+      setLoading(true);
+      const params: ReportListParams = {};
+      
+      if (filterMode === 'date') {
+        if (startDate) params.startDate = startDate;
+        if (endDate) params.endDate = endDate;
       }
-      return true;
-    });
+      
+      params.pageSize = 10;
+
+      const response = await getReportList(params);
+      if (response.isSuccess && response.result) {
+        setReports(response.result.data);
+        setHasNext(response.result.hasNext);
+        setNextCursor(response.result.nextCursor);
+      }
+    } catch (error) {
+      console.error('분석본 목록 조회 실패:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchReports();
+  }, [filterMode, startDate, endDate]);
 
   const handleNewAnalysis = () => {
     navigate('/analytics/new');
@@ -187,38 +147,43 @@ export function Analytics() {
             </button>
 
             {/* 기존 분석 카드 */}
-            {filteredAnalyses.map((analysis) => (
-              <Card
-                key={analysis.id}
-                onClick={() => handleCardClick(analysis.id)}
-                className="h-48 p-5 border border-sky-100 hover:shadow-lg hover:border-sky-300 transition-all cursor-pointer group"
-              >
-                <div className="flex flex-col h-full">
-                  {/* Repository 이름 */}
-                  <div className="flex items-start justify-between mb-3">
-                    <h3 className="text-gray-900 group-hover:text-sky-700 transition-colors line-clamp-1">
-                      {analysis.repoName}
-                    </h3>
-                    {analysis.isPublic && (
-                      <Badge className="bg-green-100 text-green-700 text-xs border-0 hover:bg-green-100">
-                        공개
-                      </Badge>
-                    )}
-                  </div>
+            {loading ? (
+              <div className="col-span-full flex items-center justify-center py-12">
+                <div className="text-gray-500">분석본 목록을 불러오는 중...</div>
+              </div>
+            ) : reports.length === 0 ? (
+              <div className="col-span-full flex items-center justify-center py-12">
+                <div className="text-gray-500">분석본이 없습니다. 새 레포지토리 분석을 시작해보세요!</div>
+              </div>
+            ) : (
+              reports.map((report) => (
+                <Card
+                  key={report.reportId}
+                  onClick={() => handleCardClick(report.reportId.toString())}
+                  className="h-48 p-5 border border-sky-100 hover:shadow-lg hover:border-sky-300 transition-all cursor-pointer group"
+                >
+                  <div className="flex flex-col h-full">
+                    {/* Repository 이름 */}
+                    <div className="flex items-start justify-between mb-3">
+                      <h3 className="text-gray-900 group-hover:text-sky-700 transition-colors line-clamp-1">
+                        {report.reopName || `분석본 #${report.reportId}`}
+                      </h3>
+                    </div>
 
-                  {/* 설명 */}
-                  <p className="text-sm text-gray-600 line-clamp-2 mb-auto">
-                    {analysis.description}
-                  </p>
+                    {/* 설명 */}
+                    <p className="text-sm text-gray-600 line-clamp-2 mb-auto">
+                      {report.description || '레포지토리 분석 결과'}
+                    </p>
 
-                  {/* 생성일 */}
-                  <div className="flex items-center gap-2 text-xs text-gray-500 mt-4">
-                    <Calendar className="w-3 h-3" />
-                    <span>{formatDisplayDate(analysis.createdAt)}</span>
+                    {/* 생성일 */}
+                    <div className="flex items-center gap-2 text-xs text-gray-500 mt-4">
+                      <Calendar className="w-3 h-3" />
+                      <span>{formatDisplayDate(new Date(report.createdAt).toISOString().split('T')[0])}</span>
+                    </div>
                   </div>
-                </div>
-              </Card>
-            ))}
+                </Card>
+              ))
+            )}
           </div>
         </Card>
       </div>


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #49

## 📌 PR 제목
<!-- 간단하게 기능/버그 수정 요약  -->
API 연동:
GET /api/v1/reports API와 완전 연동
getReportList 함수로 분석본 목록 조회
Query 파라미터 지원 (cursor, pageSize, startDate, endDate, status)
데이터 구조 수정:
Mock 데이터 → 실제 API 데이터 사용
ReportListItem 타입에 맞게 데이터 표시
오타 수정: reopName → repoName
상태 관리:
loading: 로딩 상태 처리
reports: API 응답 데이터 저장
hasNext, nextCursor: 페이징용 (미래 확장성)
UI 개선:
로딩 상태: "분석본 목록을 불러오는 중..." 표시
데이터 없음: "분석본이 없습니다. 새 레포지토리 분석을 시작해보세요!" 표시
실제 데이터: repoName, description, createdAt 표시
필터링 기능:
전체 모드: 모든 분석본 표시
기간별 조회: startDate, endDate로 필터링
초기화 버튼: 날짜 필터 초기화
📱 사용자 경험:
실시간 데이터: API 응답 즉시 반영
날짜 형식: toLocaleDateString으로 한국식 표기
기본값 처리: repoName이 null이면 "분석본 #ID" 표시
설명 처리: description이 null이면 기본 메시지 표시
🎯 API 연동 흐름:
페이지 진입 → fetchReports() 호출
파라미터 설정 → filterMode, 날짜에 따라 쿼리 구성
API 호출 → getReportList(params)
데이터 처리 → reports, hasNext, nextCursor 저장
UI 렌더링 → 로딩/데이터/빈상태 처리
🔧 기술적 특징:
타입 안전: TypeScript 타입 완전 적용
에러 처리: try-catch로 API 오류 처리
의존성: useEffect로 필터 변경시 자동 재조회
확장성: hasNext, nextCursor로 무한 스크롤 가능


## 📝 작업 내용
API 타입 수정: repoName → reopName (백엔드 응답에 맞춤)
UI 코드 수정: report.repoName → report.reopName
🎯 정상적으로 표시되는 데이터:
✅ 레포지토리 이름: "Git-Turl/git-turl-frontend", "jeongkyueun/HotSWUPot" 등
✅ 설명: 각 프로젝트의 상세 설명
✅ 생성일: "2026.05.12" 형식으로 표시
✅ 카드 클릭: 상세 페이지로 정상 이동
📱 사용자 경험:
목록 조회: 실제 생성된 5개 분석본 표시
클릭 이동: 각 카드 클릭 시 상세 페이지로 이동
데이터 표시: API 응답의 모든 정보 정확히 표시

## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
