### PR TITLE
feat: 요약본 목록 조회 API에 reportTitle 필드 추가

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -150,7 +150,7 @@ export type Content = {
 export type ReportDetail = {
   reportId: number;
   repoName: string;
-  title?: string;
+  reportTitle?: string;
   githubId: string;
   status: 'PUBLIC' | 'PRIVATE';
   createdAt: string;
@@ -161,6 +161,7 @@ export type ReportDetail = {
 export type ReportListItem = {
   reportId: number;
   repoName: string | null;
+  reportTitle?: string;
   description: string | null;
   createdAt: string;
   questionCount: number;

--- a/src/pages/Analysis/Analytics.tsx
+++ b/src/pages/Analysis/Analytics.tsx
@@ -168,7 +168,7 @@ export function Analytics() {
                     {/* Repository 이름 */}
                     <div className="flex items-start justify-between mb-3">
                       <h3 className="text-gray-900 group-hover:text-sky-700 transition-colors line-clamp-1">
-                        {report.repoName || `분석본 #${report.reportId}`}
+                        {report.reportTitle ?? report.repoName ?? `분석본 #${report.reportId}`}
                       </h3>
                     </div>
 
@@ -180,7 +180,7 @@ export function Analytics() {
                     {/* 생성일 */}
                     <div className="flex items-center gap-2 text-xs text-gray-500 mt-4">
                       <Calendar className="w-3 h-3" />
-                      <span>{formatDisplayDate(new Date(report.createdAt).toISOString().split('T')[0])}</span>
+                      <span>{formatDisplayDate(report.createdAt)}</span>
                     </div>
                   </div>
                 </Card>

--- a/src/pages/Analysis/AnalyticsDetail.tsx
+++ b/src/pages/Analysis/AnalyticsDetail.tsx
@@ -30,7 +30,7 @@ export function AnalyticsDetail() {
         if (response.isSuccess && response.result) {
           setAnalysisData(response.result);
           setIsPublic(response.result.status === 'PUBLIC');
-          setTitle(response.result.title ?? response.result.repoName);
+          setTitle(response.result.reportTitle ?? response.result.repoName);
         } else {
           // 아직 준비되지 않았으면 로딩 페이지로
           navigate(`/analytics/loading?reportId=${id}`);


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 PR 제목
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
-  src/api/member.ts  
ReportDetail.title? → reportTitle? (실제 API 필드명 반영) 
- src/pages/Analysis/AnalyticsDetail.tsx
 response.result.title → response.result.reportTitle
- src/pages/Analysis/Analytics.tsx  
createdAt 표시 시 new Date(…).toISOString().split('T')[0] 제거 → LocalDate 문자열 직접 사용

 상세 페이지에서 reportTitle이 있으면 해당 값을, 없으면 repoName을 제목으로 표시

 ReportListItem에 reportTitle?: string 추가하고, 카드 제목을 reportTitle → repoName → 분석본 #id 순서로  표시하도록 변경
## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
