### PR TITLE
feat: 질문 목록 조회 & 선택한 요약본 토대로 질문 생성 API 연동

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -355,6 +355,70 @@ export type UpdateReportTitleResult = {
   updatedAt: string;
 };
 
+/**
+ * 질문 목록 조회
+ * GET /api/v1/reports/{reportId}/questions
+ */
+export type QuestionItem = {
+  questionId: number;
+  content: string | null;
+  createdAt: string;
+  status: 'PROCESSING' | 'DONE';
+  time: number | null;
+};
+
+export type QuestionListResponse = {
+  data: QuestionItem[];
+  nextCursor: string;
+  hasNext: boolean;
+  pageSize: number;
+};
+
+export type QuestionListParams = {
+  cursor?: string;
+  pageSize?: number;
+  answerType: 'TEXT' | 'VOICE';
+};
+
+export const getQuestions = async (
+  reportId: number,
+  params: QuestionListParams
+): Promise<ApiResponse<QuestionListResponse>> => {
+  const queryParams = new URLSearchParams();
+  queryParams.append('answerType', params.answerType);
+  if (params.cursor) queryParams.append('cursor', params.cursor);
+  if (params.pageSize) queryParams.append('pageSize', params.pageSize.toString());
+
+  const response = await client.get<ApiResponse<QuestionListResponse>>(
+    `/api/v1/reports/${reportId}/questions?${queryParams.toString()}`
+  );
+  return response.data;
+};
+
+/**
+ * 질문 생성
+ * POST /api/v1/reports/{reportId}/questions
+ */
+export type CreateQuestionsRequest = {
+  questionCount: number;
+  answerType: 'TEXT' | 'VOICE';
+};
+
+export type CreateQuestionsResult = {
+  questionIdList: number[];
+};
+
+export const createQuestions = async (
+  reportId: number,
+  data: CreateQuestionsRequest
+): Promise<ApiResponse<CreateQuestionsResult>> => {
+  const response = await client.post<ApiResponse<CreateQuestionsResult>>(
+    `/api/v1/reports/${reportId}/questions`,
+    data
+  );
+  return response.data;
+};
+
 export const updateReportTitle = async (
   reportId: number,
   data: UpdateReportTitleRequest

--- a/src/pages/Analysis/AnalyticsDetail.tsx
+++ b/src/pages/Analysis/AnalyticsDetail.tsx
@@ -4,7 +4,7 @@ import { ChevronRight, FileDown, Pencil, Check, X } from 'lucide-react';
 import { Card } from '../../components/ui/card';
 import { Button } from '../../components/ui/button';
 import { Badge } from '../../components/ui/badge';
-import { getReportDetail, updateReportStatus, updateReportTitle } from '../../api/member';
+import { getReportDetail, updateReportStatus, updateReportTitle, createQuestions } from '../../api/member';
 
 export function AnalyticsDetail() {
   const { id } = useParams();
@@ -17,6 +17,10 @@ export function AnalyticsDetail() {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [titleInput, setTitleInput] = useState('');
   const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
+  const [showQuestionForm, setShowQuestionForm] = useState(false);
+  const [questionCount, setQuestionCount] = useState(3);
+  const [answerType, setAnswerType] = useState<'TEXT' | 'VOICE'>('TEXT');
+  const [isCreatingQuestions, setIsCreatingQuestions] = useState(false);
 
   useEffect(() => {
     const fetchReportDetail = async () => {
@@ -85,8 +89,26 @@ export function AnalyticsDetail() {
     alert('PDF 다운로드 기능이 실행됩니다.');
   };
 
-  const handleGenerateInterview = () => {
-    navigate('/interview');
+  const handleCreateQuestions = async () => {
+    if (!id || isCreatingQuestions) return;
+
+    setIsCreatingQuestions(true);
+    try {
+      const response = await createQuestions(Number(id), { questionCount, answerType });
+      if (response.isSuccess) {
+        setShowQuestionForm(false);
+        navigate(
+          answerType === 'VOICE'
+            ? '/voice-interview'
+            : `/interview/detail/${id}`
+        );
+      }
+    } catch (error: any) {
+      console.error('질문 생성 실패:', error);
+      alert('질문 생성에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsCreatingQuestions(false);
+    }
   };
 
   const handleStatusToggle = async () => {
@@ -371,14 +393,79 @@ export function AnalyticsDetail() {
             </div>
           </div>
 
-          {/* 면접 질문 생성 버튼 */}
-          <div className="flex justify-center pt-6 border-t border-gray-200">
-            <button
-              onClick={handleGenerateInterview}
-              className="px-8 py-3 bg-sky-400 text-white rounded-lg font-medium hover:bg-sky-500 transition-colors shadow-sm hover:shadow-md"
-            >
-              면접 질문 생성
-            </button>
+          {/* 면접 질문 생성 */}
+          <div className="flex flex-col items-center gap-4 pt-6 border-t border-gray-200">
+            {!showQuestionForm ? (
+              <button
+                onClick={() => setShowQuestionForm(true)}
+                className="px-8 py-3 bg-sky-400 text-white rounded-lg font-medium hover:bg-sky-500 transition-colors shadow-sm hover:shadow-md"
+              >
+                면접 질문 생성
+              </button>
+            ) : (
+              <div className="w-full max-w-md bg-sky-50 rounded-xl p-6 border border-sky-200">
+                <h3 className="text-gray-900 font-medium mb-5">질문 생성 설정</h3>
+
+                {/* 답변 유형 */}
+                <div className="mb-5">
+                  <p className="text-sm text-gray-700 mb-2">답변 유형</p>
+                  <div className="flex gap-2">
+                    {(['TEXT', 'VOICE'] as const).map((type) => (
+                      <button
+                        key={type}
+                        onClick={() => setAnswerType(type)}
+                        className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
+                          answerType === type
+                            ? 'bg-sky-500 text-white'
+                            : 'bg-white text-gray-600 border border-gray-200 hover:border-sky-300'
+                        }`}
+                      >
+                        {type === 'TEXT' ? '텍스트' : '음성'}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* 질문 개수 */}
+                <div className="mb-6">
+                  <p className="text-sm text-gray-700 mb-2">
+                    질문 개수{' '}
+                    <span className="text-sky-600 font-semibold">{questionCount}개</span>
+                  </p>
+                  <input
+                    type="range"
+                    min={1}
+                    max={5}
+                    value={questionCount}
+                    onChange={(e) => setQuestionCount(Number(e.target.value))}
+                    className="w-full accent-sky-500"
+                  />
+                  <div className="flex justify-between text-xs text-gray-400 mt-1">
+                    {[1, 2, 3, 4, 5].map((n) => (
+                      <span key={n}>{n}</span>
+                    ))}
+                  </div>
+                </div>
+
+                {/* 액션 버튼 */}
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setShowQuestionForm(false)}
+                    disabled={isCreatingQuestions}
+                    className="flex-1 py-2 text-sm text-gray-600 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
+                  >
+                    취소
+                  </button>
+                  <button
+                    onClick={handleCreateQuestions}
+                    disabled={isCreatingQuestions}
+                    className="flex-1 py-2 text-sm text-white bg-sky-400 rounded-lg hover:bg-sky-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isCreatingQuestions ? '생성 중...' : '생성하기'}
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         </Card>
       </div>

--- a/src/pages/Interview/Interview.tsx
+++ b/src/pages/Interview/Interview.tsx
@@ -1,32 +1,59 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router';
 import { Plus, Calendar, MessageSquare } from 'lucide-react';
 import { Card } from '../../components/ui/card';
+import { getReportList, getQuestions, type ReportListItem } from '../../api/member';
 
 export function Interview() {
   const [filterMode, setFilterMode] = useState<'all' | 'date'>('all');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
+  const [reports, setReports] = useState<ReportListItem[]>([]);
+  const [questionDates, setQuestionDates] = useState<Record<number, string>>({});
+  const [loading, setLoading] = useState(true);
 
-  // 임시 데이터
-  const interviews = [
-    { id: 1, repoName: '쇼핑몰-클론코딩', questionCount: 5, createdAt: '2026.01.15' },
-    { id: 2, repoName: '리액트-렌더링-최적화', questionCount: 3, createdAt: '2026.01.10' },
-    { id: 3, repoName: 'graphql-연습', questionCount: 4, createdAt: '2025.12.28' },
-    { id: 4, repoName: '간단-추천모델', questionCount: 5, createdAt: '2025.12.20' },
-  ];
+  useEffect(() => {
+    const fetchReports = async () => {
+      setLoading(true);
+      try {
+        const params: Parameters<typeof getReportList>[0] = {
+          answerType: 'TEXT',
+          pageSize: 20,
+        };
+        if (filterMode === 'date') {
+          if (startDate) params.startDate = startDate;
+          if (endDate) params.endDate = endDate;
+        }
+        const response = await getReportList(params);
+        if (response.isSuccess && response.result) {
+          const data = response.result.data;
+          setReports(data);
 
-  const filteredInterviews = interviews.filter((interview) => {
-    if (filterMode === 'all') return true;
-
-    const itemDate = new Date(interview.createdAt.replace(/\./g, '-'));
-    const start = startDate ? new Date(startDate) : null;
-    const end = endDate ? new Date(endDate) : null;
-
-    if (start && itemDate < start) return false;
-    if (end && itemDate > end) return false;
-    return true;
-  });
+          // 각 리포트의 질문 생성일을 병렬로 조회
+          const dateEntries = await Promise.all(
+            data.map(async (report) => {
+              try {
+                const qRes = await getQuestions(report.reportId, {
+                  answerType: 'TEXT',
+                  pageSize: 1,
+                });
+                const firstQ = qRes.result?.data[0];
+                return [report.reportId, firstQ?.createdAt ?? ''] as const;
+              } catch {
+                return [report.reportId, ''] as const;
+              }
+            })
+          );
+          setQuestionDates(Object.fromEntries(dateEntries));
+        }
+      } catch (error) {
+        console.error('면접 질문 목록 조회 실패:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchReports();
+  }, [filterMode, startDate, endDate]);
 
   return (
     <div className="min-h-screen p-8 bg-[#F0F9FF]">
@@ -120,11 +147,21 @@ export function Interview() {
             </Link>
 
             {/* 기존 면접 카드 */}
-            {filteredInterviews.length > 0 ? (
-              filteredInterviews.map((interview) => (
+            {loading ? (
+              <div className="col-span-full flex items-center justify-center py-12">
+                <div className="text-gray-500">면접 질문 목록을 불러오는 중...</div>
+              </div>
+            ) : reports.length === 0 ? (
+              <div className="col-span-full text-center py-12 text-gray-500">
+                {filterMode === 'date'
+                  ? '해당 기간에 생성된 면접 질문이 없습니다.'
+                  : '아직 생성된 면접 질문이 없습니다.'}
+              </div>
+            ) : (
+              reports.map((report) => (
                 <Link
-                  key={interview.id}
-                  to={`/interview/detail/${interview.id}`}
+                  key={report.reportId}
+                  to={`/interview/detail/${report.reportId}`}
                   className="block"
                 >
                   <Card className="h-48 p-5 border border-sky-100 hover:shadow-lg hover:border-sky-300 transition-all cursor-pointer group">
@@ -132,32 +169,32 @@ export function Interview() {
                       {/* Repository 이름 */}
                       <div className="flex items-start justify-between mb-3">
                         <h3 className="text-gray-900 group-hover:text-sky-700 transition-colors line-clamp-1 font-medium">
-                          {interview.repoName}
+                          {report.reportTitle ?? report.repoName ?? `분석본 #${report.reportId}`}
                         </h3>
-                        <div className="flex items-center gap-1 px-2 py-1 bg-sky-50 text-sky-700 rounded text-xs font-medium">
+                        <div className="flex items-center gap-1 px-2 py-1 bg-sky-50 text-sky-700 rounded text-xs font-medium shrink-0 ml-2">
                           <MessageSquare className="w-3 h-3" />
-                          <span>{interview.questionCount}</span>
+                          <span>{report.questionCount}</span>
                         </div>
                       </div>
 
-                      {/* 설명/정보 */}
-                      <p className="text-sm text-gray-600 mb-auto">
-                        면접 질문 {interview.questionCount}개
+                      {/* 설명 */}
+                      <p className="text-sm text-gray-600 mb-auto line-clamp-2">
+                        {report.description || `면접 질문 ${report.questionCount}개`}
                       </p>
 
-                      {/* 생성일 */}
+                      {/* 질문 생성일 */}
                       <div className="flex items-center gap-2 text-xs text-gray-500 mt-4">
                         <Calendar className="w-3 h-3" />
-                        <span>{interview.createdAt}</span>
+                        <span>
+                          {questionDates[report.reportId]
+                            ? questionDates[report.reportId].replace(/-/g, '.')
+                            : report.createdAt.replace(/-/g, '.')}
+                        </span>
                       </div>
                     </div>
                   </Card>
                 </Link>
               ))
-            ) : filterMode === 'date' && (
-              <div className="col-span-full text-center py-12 text-gray-500">
-                해당 기간에 생성된 면접 질문이 없습니다.
-              </div>
             )}
           </div>
         </Card>

--- a/src/pages/Interview/InterviewDetail.tsx
+++ b/src/pages/Interview/InterviewDetail.tsx
@@ -1,68 +1,155 @@
-import { useState } from 'react';
-import { Link } from 'react-router';
+import { useState, useEffect, useRef } from 'react';
+import { Link, useParams } from 'react-router';
 import { ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
 import { Card } from '../../components/ui/card';
 import { Button } from '../../components/ui/button';
+import { getReportDetail, getQuestions, type QuestionItem } from '../../api/member';
 
-interface Question {
-  id: number;
-  question: string;
+type LocalQuestion = QuestionItem & {
   answer: string;
   feedback: string;
   isGeneratingFeedback: boolean;
-}
+};
 
 export function InterviewDetail() {
-  const [questions, setQuestions] = useState<Question[]>([
-    {
-      id: 1,
-      question: '쇼핑몰 프로젝트에서 구현한 기능 중 가장 어려웠던 부분은 무엇이었나요?',
-      answer: '',
-      feedback: '',
-      isGeneratingFeedback: false,
-    },
-    {
-      id: 2,
-      question: 'JWT 인증 구현하면서 겪었던 문제와 해결 방법을 설명해주세요.',
-      answer: '',
-      feedback: '',
-      isGeneratingFeedback: false,
-    },
-    {
-      id: 3,
-      question: '로그인 상태를 유지하기 위해 어떤 방식으로 처리하셨나요?',
-      answer: '',
-      feedback: '',
-      isGeneratingFeedback: false,
-    },
-    {
-      id: 4,
-      question: 'API 요청/응답 구조를 설계할 때 어떤 기준으로 나누셨나요?',
-      answer: '',
-      feedback: '',
-      isGeneratingFeedback: false,
-    },
-    {
-      id: 5,
-      question: '프로젝트 진행하면서 코드 구조를 개선했던 경험이 있다면 설명해주세요.',
-      answer: '',
-      feedback: '',
-      isGeneratingFeedback: false,
-    },
-  ]);
-
+  const { id } = useParams();
+  const [reportName, setReportName] = useState('');
+  const [reportCreatedAt, setReportCreatedAt] = useState('');
+  const [questions, setQuestions] = useState<LocalQuestion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pollingTimedOut, setPollingTimedOut] = useState(false);
   const [openQuestions, setOpenQuestions] = useState<Set<number>>(new Set());
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollAttemptsRef = useRef(0);
+  const questionsRef = useRef<LocalQuestion[]>([]);
   const [editingAnswer, setEditingAnswer] = useState<number | null>(null);
   const [answerInput, setAnswerInput] = useState<string>('');
 
-  const toggleQuestion = (questionId: number) => {
-    const newOpenQuestions = new Set(openQuestions);
-    if (newOpenQuestions.has(questionId)) {
-      newOpenQuestions.delete(questionId);
-    } else {
-      newOpenQuestions.add(questionId);
+  questionsRef.current = questions;
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!id) return;
+      setLoading(true);
+      try {
+        const [reportRes, questionsRes] = await Promise.all([
+          getReportDetail(Number(id)),
+          getQuestions(Number(id), { answerType: 'TEXT', pageSize: 20 }),
+        ]);
+
+        if (reportRes.isSuccess && reportRes.result) {
+          setReportName(
+            reportRes.result.reportTitle ?? reportRes.result.repoName
+          );
+        }
+
+        if (questionsRes.isSuccess && questionsRes.result) {
+          const data = questionsRes.result.data;
+          setQuestions(
+            data.map((q) => ({
+              ...q,
+              answer: '',
+              feedback: '',
+              isGeneratingFeedback: false,
+            }))
+          );
+          if (data.length > 0) {
+            setReportCreatedAt(data[0].createdAt.replace(/-/g, '.'));
+          }
+        }
+      } catch (error) {
+        console.error('데이터 조회 실패:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [id]);
+
+  // PROCESSING 질문이 있는 동안 10초마다 재조회 (최대 30회 = 5분)
+  useEffect(() => {
+    if (loading || !id) return;
+
+    pollAttemptsRef.current = 0;
+
+    const intervalId = setInterval(async () => {
+      const hasProcessing = questionsRef.current.some(
+        (q) => q.status === 'PROCESSING'
+      );
+      if (!hasProcessing) {
+        clearInterval(intervalId);
+        return;
+      }
+
+      pollAttemptsRef.current += 1;
+      if (pollAttemptsRef.current > 30) {
+        clearInterval(intervalId);
+        setPollingTimedOut(true);
+        return;
+      }
+
+      try {
+        const res = await getQuestions(Number(id), {
+          answerType: 'TEXT',
+          pageSize: 20,
+        });
+        if (res.isSuccess && res.result) {
+          setQuestions((prev) =>
+            res.result!.data.map((q) => {
+              const existing = prev.find((p) => p.questionId === q.questionId);
+              return {
+                ...q,
+                answer: existing?.answer ?? '',
+                feedback: existing?.feedback ?? '',
+                isGeneratingFeedback: existing?.isGeneratingFeedback ?? false,
+              };
+            })
+          );
+        }
+      } catch (error) {
+        console.error('질문 목록 갱신 실패:', error);
+      }
+    }, 10000);
+
+    pollingRef.current = intervalId;
+    return () => clearInterval(intervalId);
+  }, [loading, id]);
+
+  const handleManualRefresh = async () => {
+    if (!id) return;
+    setPollingTimedOut(false);
+    pollAttemptsRef.current = 0;
+    try {
+      const res = await getQuestions(Number(id), {
+        answerType: 'TEXT',
+        pageSize: 20,
+      });
+      if (res.isSuccess && res.result) {
+        setQuestions((prev) =>
+          res.result!.data.map((q) => {
+            const existing = prev.find((p) => p.questionId === q.questionId);
+            return {
+              ...q,
+              answer: existing?.answer ?? '',
+              feedback: existing?.feedback ?? '',
+              isGeneratingFeedback: existing?.isGeneratingFeedback ?? false,
+            };
+          })
+        );
+      }
+    } catch (error) {
+      console.error('새로고침 실패:', error);
     }
-    setOpenQuestions(newOpenQuestions);
+  };
+
+  const toggleQuestion = (questionId: number) => {
+    const next = new Set(openQuestions);
+    if (next.has(questionId)) {
+      next.delete(questionId);
+    } else {
+      next.add(questionId);
+    }
+    setOpenQuestions(next);
   };
 
   const startEditingAnswer = (questionId: number, currentAnswer: string) => {
@@ -71,9 +158,11 @@ export function InterviewDetail() {
   };
 
   const saveAnswer = (questionId: number) => {
-    setQuestions(questions.map(q =>
-      q.id === questionId ? { ...q, answer: answerInput } : q
-    ));
+    setQuestions(
+      questions.map((q) =>
+        q.questionId === questionId ? { ...q, answer: answerInput } : q
+      )
+    );
     setEditingAnswer(null);
     setAnswerInput('');
   };
@@ -84,14 +173,14 @@ export function InterviewDetail() {
   };
 
   const generateFeedback = (questionId: number) => {
-    // 생성 중 상태 설정
-    setQuestions(questions.map(q =>
-      q.id === questionId ? { ...q, isGeneratingFeedback: true } : q
-    ));
+    setQuestions(
+      questions.map((q) =>
+        q.questionId === questionId ? { ...q, isGeneratingFeedback: true } : q
+      )
+    );
 
-    // 시뮬레이션 API 호출
     setTimeout(() => {
-      const mockFeedback = `훌륭한 답변입니다! 기술적 이해도가 높으며, 실제 프로젝트 경험을 바탕으로 구체적인 예시를 들어 설명하셨습니다. 
+      const mockFeedback = `훌륭한 답변입니다! 기술적 이해도가 높으며, 실제 프로젝트 경험을 바탕으로 구체적인 예시를 들어 설명하셨습니다.
 
 개선할 점:
 1. 구체적인 성능 지표나 수치를 포함하면 더 설득력이 있을 것 같습니다.
@@ -99,11 +188,26 @@ export function InterviewDetail() {
 
 전반적으로 매우 우수한 답변입니다. 실무 경험이 잘 드러나고 있습니다.`;
 
-      setQuestions(questions.map(q =>
-        q.id === questionId ? { ...q, feedback: mockFeedback, isGeneratingFeedback: false } : q
-      ));
+      setQuestions((prev) =>
+        prev.map((q) =>
+          q.questionId === questionId
+            ? { ...q, feedback: mockFeedback, isGeneratingFeedback: false }
+            : q
+        )
+      );
     }, 2000);
   };
+
+  const displayName = reportName || `분석본 #${id}`;
+  const doneCount = questions.filter((q) => q.status === 'DONE').length;
+
+  if (loading) {
+    return (
+      <div className="min-h-screen p-8 bg-[#F0F9FF] flex items-center justify-center">
+        <div className="text-gray-500">질문 목록을 불러오는 중...</div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen p-8 bg-[#F0F9FF]">
@@ -117,149 +221,212 @@ export function InterviewDetail() {
             면접
           </Link>
           <ChevronRight className="w-4 h-4 text-gray-400" />
-          <span className="text-gray-600">쇼핑몰-클론코딩</span>
+          <span className="text-gray-600">{displayName}</span>
         </div>
 
         <Card className="p-8 bg-white border border-sky-100 shadow-sm">
           {/* 헤더 */}
           <div className="mb-8 pb-6 border-b border-gray-200">
             <h1 className="text-2xl text-gray-900 mb-2">
-              면접 질문 / 쇼핑몰-클론코딩
+              면접 질문 / {displayName}
             </h1>
             <p className="text-sm text-gray-500">
-              생성일: 2026.01.15 • 질문 {questions.length}개
+              {reportCreatedAt && `생성일: ${reportCreatedAt} • `}
+              질문 {doneCount}개
+              {questions.some((q) => q.status === 'PROCESSING') && (
+                <span className="ml-2 text-sky-600">
+                  ({questions.filter((q) => q.status === 'PROCESSING').length}개 생성 중)
+                </span>
+              )}
             </p>
           </div>
 
+          {/* 생성 지연 안내 배너 */}
+          {pollingTimedOut && questions.some((q) => q.status === 'PROCESSING') && (
+            <div className="mb-6 p-4 bg-amber-50 border border-amber-200 rounded-lg flex items-center justify-between gap-4">
+              <p className="text-sm text-amber-800">
+                질문 생성에 예상보다 오랜 시간이 걸리고 있습니다. 잠시 후 다시 확인해주세요.
+              </p>
+              <Button
+                onClick={handleManualRefresh}
+                variant="outline"
+                className="shrink-0 text-sm border-amber-300 text-amber-700 hover:bg-amber-100"
+              >
+                새로고침
+              </Button>
+            </div>
+          )}
+
           {/* 질문 목록 */}
-          <div className="space-y-4">
-            {questions.map((q, index) => (
-              <div key={q.id} className="border border-gray-200 rounded-lg overflow-hidden">
-                {/* 질문 헤더 */}
-                <button
-                  onClick={() => toggleQuestion(q.id)}
-                  className="w-full p-5 flex items-start justify-between bg-white hover:bg-gray-50 transition-colors text-left"
+          {questions.length === 0 ? (
+            <div className="text-center py-12 text-gray-500">
+              아직 생성된 질문이 없습니다.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {questions.map((q, index) => (
+                <div
+                  key={q.questionId}
+                  className="border border-gray-200 rounded-lg overflow-hidden"
                 >
-                  <div className="flex-1 flex items-start gap-3">
-                    <span className="flex-shrink-0 w-6 h-6 rounded-full bg-sky-100 text-sky-700 text-sm font-medium flex items-center justify-center mt-0.5">
-                      {index + 1}
-                    </span>
-                    <p className="text-gray-900 font-medium">{q.question}</p>
-                  </div>
-                  {openQuestions.has(q.id) ? (
-                    <ChevronDown className="w-5 h-5 text-gray-400 flex-shrink-0 ml-2" />
-                  ) : (
-                    <ChevronRight className="w-5 h-5 text-gray-400 flex-shrink-0 ml-2" />
-                  )}
-                </button>
-
-                {/* 질문 내용 */}
-                {openQuestions.has(q.id) && (
-                  <div className="p-5 pt-4 bg-gray-50 border-t border-gray-200">
-                    {/* 답변 섹션 */}
-                    <div className="mb-4">
-                      <h3 className="text-sm font-medium text-gray-700 mb-4">답변</h3>
-
-                      {editingAnswer === q.id ? (
-                        // 답변 편집 모드
-                        <div className="space-y-4">
-                          <textarea
-                            value={answerInput}
-                            onChange={(e) => setAnswerInput(e.target.value)}
-                            maxLength={200}
-                            placeholder="답변을 입력하세요 (최대 200자)"
-                            className="w-full p-4 border border-sky-200 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-sky-500 bg-white"
-                            rows={6}
-                          />
-                          <div className="flex items-center justify-between">
-                            <span className="text-sm text-gray-500">
-                              {answerInput.length} / 200
-                            </span>
-                            <div className="flex gap-2">
-                              <Button
-                                onClick={cancelEditingAnswer}
-                                variant="outline"
-                                className="px-4 py-2 text-sm border-gray-300 text-gray-700 hover:bg-gray-50"
-                              >
-                                취소
-                              </Button>
-                              <Button
-                                onClick={() => saveAnswer(q.id)}
-                                disabled={answerInput.length === 0}
-                                className={`px-4 py-2 text-sm ${answerInput.length > 0
-                                    ? 'bg-sky-600 text-white hover:bg-sky-700'
-                                    : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                                  }`}
-                              >
-                                저장하기
-                              </Button>
-                            </div>
-                          </div>
-                        </div>
-                      ) : q.answer ? (
-                        // 답변 표시 모드
-                        <div className="space-y-4">
-                          <div className="p-4 bg-white border border-gray-200 rounded-lg">
-                            <p className="text-gray-700 whitespace-pre-wrap">{q.answer}</p>
-                          </div>
-                          <div className="flex gap-2 justify-end">
-                            <Button
-                              onClick={() => startEditingAnswer(q.id, q.answer)}
-                              variant="outline"
-                              className="px-4 py-2 text-sm border-sky-300 text-sky-700 hover:bg-sky-50"
-                            >
-                              수정하기
-                            </Button>
-                            {!q.feedback && !q.isGeneratingFeedback && (
-                              <Button
-                                onClick={() => generateFeedback(q.id)}
-                                className="px-4 py-2 text-sm bg-sky-400 text-white hover:bg-sky-500"
-                              >
-                                피드백 받기
-                              </Button>
-                            )}
-                          </div>
+                  {/* 질문 헤더 */}
+                  <button
+                    onClick={() =>
+                      q.status === 'DONE' && toggleQuestion(q.questionId)
+                    }
+                    disabled={q.status === 'PROCESSING'}
+                    className={`w-full p-5 flex items-start justify-between bg-white text-left transition-colors ${
+                      q.status === 'DONE'
+                        ? 'hover:bg-gray-50'
+                        : 'cursor-default opacity-70'
+                    }`}
+                  >
+                    <div className="flex-1 flex items-start gap-3">
+                      <span className="flex-shrink-0 w-6 h-6 rounded-full bg-sky-100 text-sky-700 text-sm font-medium flex items-center justify-center mt-0.5">
+                        {index + 1}
+                      </span>
+                      {q.status === 'PROCESSING' || q.content === null ? (
+                        <div className="flex items-center gap-2 text-gray-500">
+                          <Loader2 className="w-4 h-4 animate-spin text-sky-500" />
+                          <span className="text-sm">질문 생성 중...</span>
                         </div>
                       ) : (
-                        // 답변 없음 상태
-                        <div className="p-6 bg-white border border-gray-200 rounded-lg text-center">
-                          <p className="text-gray-500 mb-4">아직 등록된 답변이 없습니다</p>
-                          <Button
-                            onClick={() => startEditingAnswer(q.id, '')}
-                            className="px-6 py-2 bg-sky-600 text-white hover:bg-sky-700"
-                          >
-                            답변 작성하기
-                          </Button>
+                        <p className="text-gray-900 font-medium">{q.content}</p>
+                      )}
+                    </div>
+                    {q.status === 'DONE' &&
+                      (openQuestions.has(q.questionId) ? (
+                        <ChevronDown className="w-5 h-5 text-gray-400 flex-shrink-0 ml-2" />
+                      ) : (
+                        <ChevronRight className="w-5 h-5 text-gray-400 flex-shrink-0 ml-2" />
+                      ))}
+                  </button>
+
+                  {/* 질문 상세 (펼침) */}
+                  {q.status === 'DONE' && openQuestions.has(q.questionId) && (
+                    <div className="p-5 pt-4 bg-gray-50 border-t border-gray-200">
+                      {/* 답변 섹션 */}
+                      <div className="mb-4">
+                        <h3 className="text-sm font-medium text-gray-700 mb-4">
+                          답변
+                        </h3>
+
+                        {editingAnswer === q.questionId ? (
+                          <div className="space-y-4">
+                            <textarea
+                              value={answerInput}
+                              onChange={(e) => setAnswerInput(e.target.value)}
+                              maxLength={200}
+                              placeholder="답변을 입력하세요 (최대 200자)"
+                              className="w-full p-4 border border-sky-200 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-sky-500 bg-white"
+                              rows={6}
+                            />
+                            <div className="flex items-center justify-between">
+                              <span className="text-sm text-gray-500">
+                                {answerInput.length} / 200
+                              </span>
+                              <div className="flex gap-2">
+                                <Button
+                                  onClick={cancelEditingAnswer}
+                                  variant="outline"
+                                  className="px-4 py-2 text-sm border-gray-300 text-gray-700 hover:bg-gray-50"
+                                >
+                                  취소
+                                </Button>
+                                <Button
+                                  onClick={() => saveAnswer(q.questionId)}
+                                  disabled={answerInput.length === 0}
+                                  className={`px-4 py-2 text-sm ${
+                                    answerInput.length > 0
+                                      ? 'bg-sky-600 text-white hover:bg-sky-700'
+                                      : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                                  }`}
+                                >
+                                  저장하기
+                                </Button>
+                              </div>
+                            </div>
+                          </div>
+                        ) : q.answer ? (
+                          <div className="space-y-4">
+                            <div className="p-4 bg-white border border-gray-200 rounded-lg">
+                              <p className="text-gray-700 whitespace-pre-wrap">
+                                {q.answer}
+                              </p>
+                            </div>
+                            <div className="flex gap-2 justify-end">
+                              <Button
+                                onClick={() =>
+                                  startEditingAnswer(q.questionId, q.answer)
+                                }
+                                variant="outline"
+                                className="px-4 py-2 text-sm border-sky-300 text-sky-700 hover:bg-sky-50"
+                              >
+                                수정하기
+                              </Button>
+                              {!q.feedback && !q.isGeneratingFeedback && (
+                                <Button
+                                  onClick={() => generateFeedback(q.questionId)}
+                                  className="px-4 py-2 text-sm bg-sky-400 text-white hover:bg-sky-500"
+                                >
+                                  피드백 받기
+                                </Button>
+                              )}
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="p-6 bg-white border border-gray-200 rounded-lg text-center">
+                            <p className="text-gray-500 mb-4">
+                              아직 등록된 답변이 없습니다
+                            </p>
+                            <Button
+                              onClick={() =>
+                                startEditingAnswer(q.questionId, '')
+                              }
+                              className="px-6 py-2 bg-sky-600 text-white hover:bg-sky-700"
+                            >
+                              답변 작성하기
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+
+                      {/* 피드백 섹션 */}
+                      {q.isGeneratingFeedback && (
+                        <div className="mt-4 p-4 bg-sky-50 border border-sky-200 rounded-lg">
+                          <div className="flex items-center gap-3">
+                            <Loader2 className="w-5 h-5 text-sky-600 animate-spin" />
+                            <p className="text-sm text-sky-700">
+                              피드백 생성 중...
+                            </p>
+                          </div>
+                          <div className="mt-3 w-full bg-sky-200 rounded-full h-1.5">
+                            <div
+                              className="bg-sky-600 h-1.5 rounded-full animate-pulse"
+                              style={{ width: '60%' }}
+                            ></div>
+                          </div>
+                        </div>
+                      )}
+
+                      {q.feedback && !q.isGeneratingFeedback && (
+                        <div className="mt-4">
+                          <h3 className="text-sm font-medium text-gray-700 mb-4">
+                            AI 피드백
+                          </h3>
+                          <div className="p-4 bg-green-50 border border-green-200 rounded-lg">
+                            <p className="text-gray-700 text-sm whitespace-pre-wrap">
+                              {q.feedback}
+                            </p>
+                          </div>
                         </div>
                       )}
                     </div>
-
-                    {/* 피드백 섹션 */}
-                    {q.isGeneratingFeedback && (
-                      <div className="mt-4 p-4 bg-sky-50 border border-sky-200 rounded-lg">
-                        <div className="flex items-center gap-3">
-                          <Loader2 className="w-5 h-5 text-sky-600 animate-spin" />
-                          <p className="text-sm text-sky-700">피드백 생성 중...</p>
-                        </div>
-                        <div className="mt-3 w-full bg-sky-200 rounded-full h-1.5">
-                          <div className="bg-sky-600 h-1.5 rounded-full animate-pulse" style={{ width: '60%' }}></div>
-                        </div>
-                      </div>
-                    )}
-
-                    {q.feedback && !q.isGeneratingFeedback && (
-                      <div className="mt-4">
-                        <h3 className="text-sm font-medium text-gray-700 mb-4">AI 피드백</h3>
-                        <div className="p-4 bg-green-50 border border-green-200 rounded-lg">
-                          <p className="text-gray-700 text-sm whitespace-pre-wrap">{q.feedback}</p>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
         </Card>
       </div>
     </div>

--- a/src/pages/Interview/InterviewNew.tsx
+++ b/src/pages/Interview/InterviewNew.tsx
@@ -1,72 +1,75 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { ArrowLeft, Check, FileText } from 'lucide-react';
 import { Card } from '../../components/ui/card';
 import { Button } from '../../components/ui/button';
+import {
+  getReportList,
+  createQuestions,
+  type ReportListItem,
+} from '../../api/member';
 
 export function InterviewNew() {
   const navigate = useNavigate();
-  const [selectedSummary, setSelectedSummary] = useState<string>('');
+  const [selectedReportId, setSelectedReportId] = useState<number | null>(null);
   const [questionCount, setQuestionCount] = useState<number>(3);
   const [filterMode, setFilterMode] = useState<'all' | 'date'>('all');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
+  const [reports, setReports] = useState<ReportListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isCreating, setIsCreating] = useState(false);
 
-  // 요약 리스트 임시 데이터
-  const summaries = [
-    {
-      name: '쇼핑몰-클론코딩',
-      description: 'JWT 인증 흐름과 장바구니 상태 관리 구현 과정 정리',
-      createdAt: '2026.01.15',
-    },
-    {
-      name: '리액트-렌더링-최적화',
-      description: 'memo/useCallback 적용 전후 렌더링 비교 정리',
-      createdAt: '2026.01.10',
-    },
-    {
-      name: 'graphql-연습',
-      description: 'REST와 GraphQL 차이 및 Resolver 구조 정리',
-      createdAt: '2025.12.28',
-    },
-    {
-      name: 'docker-배포-연습',
-      description: 'Docker 이미지 생성부터 EC2 배포까지 과정 정리',
-      createdAt: '2025.12.25',
-    },
-    {
-      name: '간단-추천모델',
-      description: '협업 필터링 기본 개념 및 구현 과정 정리',
-      createdAt: '2025.12.20',
-    },
-    {
-      name: '채팅앱-토이프로젝트',
-      description: 'Socket 통신 흐름 및 이벤트 구조 정리',
-      createdAt: '2025.12.15',
-    },
-  ];
-
-  const filteredSummaries = summaries.filter((summary) => {
-    if (filterMode === 'all') return true;
-
-    const itemDate = new Date(summary.createdAt.replace(/\./g, '-'));
-    const start = startDate ? new Date(startDate) : null;
-    const end = endDate ? new Date(endDate) : null;
-
-    if (start && itemDate < start) return false;
-    if (end && itemDate > end) return false;
-    return true;
-  });
+  useEffect(() => {
+    const fetchReports = async () => {
+      setLoading(true);
+      try {
+        const params: Parameters<typeof getReportList>[0] = {
+          answerType: 'ALL',
+          pageSize: 20,
+        };
+        if (filterMode === 'date') {
+          if (startDate) params.startDate = startDate;
+          if (endDate) params.endDate = endDate;
+        }
+        const response = await getReportList(params);
+        if (response.isSuccess && response.result) {
+          setReports(response.result.data);
+        }
+      } catch (error) {
+        console.error('요약본 목록 조회 실패:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchReports();
+  }, [filterMode, startDate, endDate]);
 
   const handleGoBack = () => {
     navigate('/interview');
   };
 
-  const handleGenerate = () => {
-    if (selectedSummary) {
-      navigate('/interview/loading');
+  const handleGenerate = async () => {
+    if (!selectedReportId || isCreating) return;
+
+    setIsCreating(true);
+    try {
+      const response = await createQuestions(selectedReportId, {
+        questionCount,
+        answerType: 'TEXT',
+      });
+      if (response.isSuccess) {
+        navigate(`/interview/detail/${selectedReportId}`);
+      }
+    } catch (error: any) {
+      console.error('질문 생성 실패:', error);
+      alert('질문 생성에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsCreating(false);
     }
   };
+
+  const selectedReport = reports.find((r) => r.reportId === selectedReportId);
 
   return (
     <div className="min-h-screen p-8 bg-[#F0F9FF]">
@@ -99,7 +102,9 @@ export function InterviewNew() {
           <Card className="p-8 bg-white border border-sky-100 shadow-sm">
             <div className="mb-6">
               <h2 className="text-xl text-gray-900 mb-2">요약본 선택</h2>
-              <p className="text-sm text-gray-600">면접 질문을 생성할 요약본을 선택해주세요</p>
+              <p className="text-sm text-gray-600">
+                면접 질문을 생성할 요약본을 선택해주세요
+              </p>
             </div>
 
             {/* 필터 모드 토글 */}
@@ -107,19 +112,21 @@ export function InterviewNew() {
               <div className="flex items-center gap-2 bg-gray-100 rounded-lg p-1">
                 <button
                   onClick={() => setFilterMode('all')}
-                  className={`px-4 py-2 rounded-md text-sm transition-all ${filterMode === 'all'
+                  className={`px-4 py-2 rounded-md text-sm transition-all ${
+                    filterMode === 'all'
                       ? 'bg-white text-sky-700 shadow-sm font-medium'
                       : 'text-gray-600 hover:text-gray-900'
-                    }`}
+                  }`}
                 >
                   전체
                 </button>
                 <button
                   onClick={() => setFilterMode('date')}
-                  className={`px-4 py-2 rounded-md text-sm transition-all ${filterMode === 'date'
+                  className={`px-4 py-2 rounded-md text-sm transition-all ${
+                    filterMode === 'date'
                       ? 'bg-white text-sky-700 shadow-sm font-medium'
                       : 'text-gray-600 hover:text-gray-900'
-                    }`}
+                  }`}
                 >
                   기간별 조회
                 </button>
@@ -130,7 +137,9 @@ export function InterviewNew() {
             {filterMode === 'date' && (
               <div className="flex items-center justify-end gap-3 mb-6 p-4 bg-sky-50 rounded-lg border border-sky-100">
                 <div className="flex items-center gap-2">
-                  <label className="text-sm text-gray-700 font-medium">시작일:</label>
+                  <label className="text-sm text-gray-700 font-medium">
+                    시작일:
+                  </label>
                   <input
                     type="date"
                     value={startDate}
@@ -142,7 +151,9 @@ export function InterviewNew() {
                 <span className="text-gray-400">~</span>
 
                 <div className="flex items-center gap-2">
-                  <label className="text-sm text-gray-700 font-medium">종료일:</label>
+                  <label className="text-sm text-gray-700 font-medium">
+                    종료일:
+                  </label>
                   <input
                     type="date"
                     value={endDate}
@@ -167,50 +178,84 @@ export function InterviewNew() {
 
             {/* 요약본 그리드 */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
-              {filteredSummaries.map((summary) => (
-                <button
-                  key={summary.name}
-                  onClick={() => setSelectedSummary(summary.name)}
-                  className={`relative p-5 border-2 rounded-xl text-left transition-all ${selectedSummary === summary.name
-                      ? 'border-sky-500 bg-sky-50 shadow-md'
-                      : 'border-gray-200 hover:border-sky-300 hover:bg-gray-50'
-                    }`}
-                >
-                  {selectedSummary === summary.name && (
-                    <div className="absolute top-4 right-4 w-6 h-6 rounded-full bg-sky-600 flex items-center justify-center">
-                      <Check className="w-4 h-4 text-white" />
-                    </div>
-                  )}
-
-                  <div className="flex items-start gap-3">
-                    <div className="mt-1">
-                      <FileText className={`w-5 h-5 ${selectedSummary === summary.name ? 'text-sky-700' : 'text-gray-400'}`} />
-                    </div>
-                    <div className="flex-1">
-                      <h3 className={`font-medium mb-1 ${selectedSummary === summary.name ? 'text-sky-900' : 'text-gray-900'}`}>
-                        {summary.name}
-                      </h3>
-                      <p className="text-sm text-gray-600 mb-2">{summary.description}</p>
-                      <p className="text-xs text-gray-500">{summary.createdAt}</p>
-                    </div>
+              {loading ? (
+                <div className="col-span-full flex items-center justify-center py-12">
+                  <div className="text-gray-500">요약본 목록을 불러오는 중...</div>
+                </div>
+              ) : reports.length === 0 ? (
+                <div className="col-span-full flex items-center justify-center py-12">
+                  <div className="text-gray-500">
+                    요약본이 없습니다. 먼저 레포지토리 분석을 시작해보세요!
                   </div>
-                </button>
-              ))}
+                </div>
+              ) : (
+                reports.map((report) => (
+                  <button
+                    key={report.reportId}
+                    onClick={() => setSelectedReportId(report.reportId)}
+                    className={`relative p-5 border-2 rounded-xl text-left transition-all ${
+                      selectedReportId === report.reportId
+                        ? 'border-sky-500 bg-sky-50 shadow-md'
+                        : 'border-gray-200 hover:border-sky-300 hover:bg-gray-50'
+                    }`}
+                  >
+                    {selectedReportId === report.reportId && (
+                      <div className="absolute top-4 right-4 w-6 h-6 rounded-full bg-sky-600 flex items-center justify-center">
+                        <Check className="w-4 h-4 text-white" />
+                      </div>
+                    )}
+
+                    <div className="flex items-start gap-3">
+                      <div className="mt-1">
+                        <FileText
+                          className={`w-5 h-5 ${
+                            selectedReportId === report.reportId
+                              ? 'text-sky-700'
+                              : 'text-gray-400'
+                          }`}
+                        />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <h3
+                          className={`font-medium mb-1 truncate ${
+                            selectedReportId === report.reportId
+                              ? 'text-sky-900'
+                              : 'text-gray-900'
+                          }`}
+                        >
+                          {report.reportTitle ??
+                            report.repoName ??
+                            `분석본 #${report.reportId}`}
+                        </h3>
+                        <p className="text-sm text-gray-600 mb-2 line-clamp-2">
+                          {report.description || '레포지토리 분석 결과'}
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          {report.createdAt.replace(/-/g, '.')}
+                        </p>
+                      </div>
+                    </div>
+                  </button>
+                ))
+              )}
             </div>
 
             {/* 질문 개수 선택기 */}
-            {selectedSummary && (
+            {selectedReportId !== null && (
               <div className="mb-6 p-6 bg-sky-50 border border-sky-200 rounded-lg">
-                <h3 className="text-sm text-gray-700 font-medium mb-4">생성할 질문 개수를 선택하세요</h3>
+                <h3 className="text-sm text-gray-700 font-medium mb-4">
+                  생성할 질문 개수를 선택하세요
+                </h3>
                 <div className="flex items-center gap-3">
                   {[1, 2, 3, 4, 5].map((num) => (
                     <button
                       key={num}
                       onClick={() => setQuestionCount(num)}
-                      className={`w-12 h-12 rounded-lg border-2 transition-all ${questionCount === num
+                      className={`w-12 h-12 rounded-lg border-2 transition-all ${
+                        questionCount === num
                           ? 'border-sky-600 bg-sky-600 text-white font-medium shadow-md'
                           : 'border-gray-300 bg-white text-gray-700 hover:border-sky-400'
-                        }`}
+                      }`}
                     >
                       {num}
                     </button>
@@ -221,13 +266,19 @@ export function InterviewNew() {
             )}
 
             {/* 선택된 요약본 */}
-            {selectedSummary && (
+            {selectedReport && (
               <div className="mb-6 p-4 bg-sky-50 border border-sky-200 rounded-lg">
                 <p className="text-sm text-gray-700">
                   <span className="text-gray-600">선택된 요약본:</span>
-                  <span className="ml-2 font-medium text-sky-700">{selectedSummary}</span>
+                  <span className="ml-2 font-medium text-sky-700">
+                    {selectedReport.reportTitle ??
+                      selectedReport.repoName ??
+                      `분석본 #${selectedReport.reportId}`}
+                  </span>
                   <span className="ml-4 text-gray-600">질문 개수:</span>
-                  <span className="ml-2 font-medium text-sky-700">{questionCount}개</span>
+                  <span className="ml-2 font-medium text-sky-700">
+                    {questionCount}개
+                  </span>
                 </p>
               </div>
             )}
@@ -245,13 +296,14 @@ export function InterviewNew() {
 
               <Button
                 onClick={handleGenerate}
-                disabled={!selectedSummary}
-                className={`px-8 py-2 ${selectedSummary
+                disabled={selectedReportId === null || isCreating}
+                className={`px-8 py-2 ${
+                  selectedReportId !== null && !isCreating
                     ? 'bg-sky-600 text-white hover:bg-sky-700 shadow-sm'
                     : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                  }`}
+                }`}
               >
-                생성하기
+                {isCreating ? '생성 중...' : '생성하기'}
               </Button>
             </div>
           </Card>


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 feat: 질문 목록 조회 & 선택한 요약본 토대로 질문 생성 API 연동
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
연동 API

  ┌────────┬──────────────────────────────────────┬────────────────┐
  │ 메서드 │              엔드포인트              │      설명      │
  ├────────┼──────────────────────────────────────┼────────────────┤
  │ POST   │ /api/v1/reports/{reportId}/questions │ 질문 생성      │
  ├────────┼──────────────────────────────────────┼────────────────┤
  │ GET    │ /api/v1/reports/{reportId}/questions │ 질문 목록 조회 │                            
  └────────┴──────────────────────────────────────┴────────────────┘

  ---
  변경 파일

  src/api/member.ts
  - CreateQuestionsRequest, CreateQuestionsResult 타입 추가
  - createQuestions(reportId, { questionCount, answerType }) 함수 추가
  - QuestionItem, QuestionListResponse, QuestionListParams 타입 추가
  - getQuestions(reportId, { answerType, cursor?, pageSize? }) 함수 추가

  src/pages/Analysis/AnalyticsDetail.tsx
  - 기존 단순 이동 버튼 → 질문 생성 설정 폼으로 교체
    - 답변 유형 (TEXT / VOICE) 선택
    - 질문 개수 1~5 슬라이더
  - 생성 성공 시 TEXT → /interview/detail/:id, VOICE → /voice-interview 이동

  src/pages/Interview/InterviewNew.tsx
  - mock 데이터 제거, getReportList({ answerType: 'ALL' }) 연동
  - 날짜 필터를 클라이언트 처리 → API 쿼리 파라미터로 변경
  - 생성 성공 시 /interview/detail/:reportId 직접 이동

  src/pages/Interview/Interview.tsx
  - mock 데이터 제거, getReportList({ answerType: 'TEXT' }) 연동
  - 각 리포트 카드 날짜를 질문 createdAt 기준으로 표시 (병렬 조회)

  src/pages/Interview/InterviewDetail.tsx
  - getReportDetail + getQuestions 병렬 호출로 실데이터 렌더링
  - status: PROCESSING 질문은 spinner 표시
  - PROCESSING 질문이 있을 경우 10초 간격 자동 폴링 (최대 30회 / 5분)
  - 폴링 종료 후에도 미완료 질문이 있으면 안내 배너 + 수동 새로고침 버튼 노출
  - 생성일 표시를 레포 분석일 → 질문 createdAt 기준으로 수정

  ---
  비동기 처리 대응

  질문 생성 API가 비동기로 동작하여 생성 직후 status: PROCESSING, content: null 상태로 반환됩니다. 이에 따라 상세      
  페이지 진입 후 완료될 때까지 자동 폴링하며, 일정 시간 초과 시 사용자에게 안내합니다.

=========================================================
- 프론트 추가 대응: 5분(30회) 후 폴링 중단 + 황색 배너 "생성에 오랜 시간이 걸리고 있습니다" + 새로고침 버튼 표시.
- 리포트 목록 조회 후 각 리포트에 대해 getQuestions(reportId, { pageSize: 1 }) 를 Promise.all로 병렬 호출 → 첫 번째 질문의        
  createdAt을 카드 날짜로 표시. 질문 조회에 실패하면 기존 report.createdAt(분석일)으로 fallback

- 질문 목록 조회 API
<img width="2182" height="932" alt="스크린샷 2026-05-25 000908" src="https://github.com/user-attachments/assets/d432bb7d-4524-4411-ae6e-e0f7ae547aa3" />

- 선택한 요약본 토대로 질문 생성 API 
<img width="2536" height="1188" alt="image" src="https://github.com/user-attachments/assets/a23cd070-47f1-4f65-be4e-5065d4352527" />


## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
