### PR TITLE
feat: 답변&피드백 삭제 API 연동

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -485,3 +485,16 @@ export const getAnswers = async (
   );
   return response.data;
 };
+
+/**
+ * 답변&피드백 삭제
+ * DELETE /api/v1/answers/{answerId}
+ */
+export const deleteAnswer = async (
+  answerId: number
+): Promise<ApiResponse<null>> => {
+  const response = await client.delete<ApiResponse<null>>(
+    `/api/v1/answers/${answerId}`
+  );
+  return response.data;
+};

--- a/src/pages/Interview/InterviewDetail.tsx
+++ b/src/pages/Interview/InterviewDetail.tsx
@@ -9,6 +9,7 @@ import {
   getAnswers,
   saveAnswer as saveAnswerApi,
   createFeedback,
+  deleteAnswer as deleteAnswerApi,
   type QuestionItem,
   type AnswerItem,
 } from '../../api/member';
@@ -222,6 +223,18 @@ export function InterviewDetail() {
   const cancelForm = () => {
     setAddingAnswerTo(null);
     setAnswerInput('');
+  };
+
+  const deleteAnswer = async (questionId: number, answerId: number) => {
+    if (!window.confirm('답변을 삭제하시겠습니까?')) return;
+    try {
+      const response = await deleteAnswerApi(answerId);
+      if (response.isSuccess) {
+        fetchAnswersForQuestion(questionId);
+      }
+    } catch {
+      alert('답변 삭제에 실패했습니다. 다시 시도해주세요.');
+    }
   };
 
   const generateFeedback = async (questionId: number, answerId: number) => {
@@ -486,16 +499,38 @@ export function InterviewDetail() {
                                   </div>
                                 </div>
                               ) : answer.feedback ? (
-                                <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
-                                  <p className="text-xs font-medium text-green-700 mb-1">
-                                    AI 피드백
-                                  </p>
-                                  <p className="text-gray-700 text-sm whitespace-pre-wrap">
-                                    {answer.feedback}
-                                  </p>
-                                </div>
+                                <>
+                                  <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
+                                    <p className="text-xs font-medium text-green-700 mb-1">
+                                      AI 피드백
+                                    </p>
+                                    <p className="text-gray-700 text-sm whitespace-pre-wrap">
+                                      {answer.feedback}
+                                    </p>
+                                  </div>
+                                  <div className="flex justify-end mt-2">
+                                    <Button
+                                      onClick={() =>
+                                        deleteAnswer(q.questionId, answer.answerId)
+                                      }
+                                      variant="outline"
+                                      className="px-4 py-1.5 text-sm border-red-200 text-red-500 hover:bg-red-50"
+                                    >
+                                      삭제
+                                    </Button>
+                                  </div>
+                                </>
                               ) : (
-                                <div className="flex justify-end">
+                                <div className="flex justify-end gap-2">
+                                  <Button
+                                    onClick={() =>
+                                      deleteAnswer(q.questionId, answer.answerId)
+                                    }
+                                    variant="outline"
+                                    className="px-4 py-1.5 text-sm border-red-200 text-red-500 hover:bg-red-50"
+                                  >
+                                    삭제
+                                  </Button>
                                   <Button
                                     onClick={() =>
                                       generateFeedback(q.questionId, answer.answerId)


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 PR 제목
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
  - deleteAnswer(answerId) — DELETE /api/v1/answers/{answerId} 추가 (member.ts)
  - 삭제 버튼은 피드백 유무와 관계없이 모든 답변 카드에 표시
  - 클릭 시 confirm 확인 후 삭제, 성공하면 getAnswers 재조회로 목록 즉시 갱신
-----
  변경 파일

  src/api/member.ts
  - deleteAnswer(answerId) — DELETE /api/v1/answers/{answerId}

  src/pages/Interview/InterviewDetail.tsx
  - 각 답변 카드에 삭제 버튼 추가 (피드백 유무 상관없이 노출)
  - 삭제 전 confirm 다이얼로그로 실수 방지
  - 삭제 성공 시 getAnswers 재호출로 목록 즉시 갱신
<img width="2526" height="884" alt="image" src="https://github.com/user-attachments/assets/37f6aa5f-6ede-442f-b3a8-0a5f01bc739c" />

## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
