### PR TITLE
feat: 질문 삭제 API 연동

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -498,3 +498,16 @@ export const deleteAnswer = async (
   );
   return response.data;
 };
+
+/**
+ * 질문 삭제
+ * DELETE /api/v1/questions/{questionId}
+ */
+export const deleteQuestion = async (
+  questionId: number
+): Promise<ApiResponse<null>> => {
+  const response = await client.delete<ApiResponse<null>>(
+    `/api/v1/questions/${questionId}`
+  );
+  return response.data;
+};

--- a/src/pages/Interview/InterviewDetail.tsx
+++ b/src/pages/Interview/InterviewDetail.tsx
@@ -10,6 +10,7 @@ import {
   saveAnswer as saveAnswerApi,
   createFeedback,
   deleteAnswer as deleteAnswerApi,
+  deleteQuestion as deleteQuestionApi,
   type QuestionItem,
   type AnswerItem,
 } from '../../api/member';
@@ -237,6 +238,23 @@ export function InterviewDetail() {
     }
   };
 
+  const deleteQuestion = async (questionId: number) => {
+    if (!window.confirm('질문을 삭제하시겠습니까? 관련 답변도 모두 삭제됩니다.')) return;
+    try {
+      const response = await deleteQuestionApi(questionId);
+      if (response.isSuccess) {
+        setQuestions((prev) => prev.filter((q) => q.questionId !== questionId));
+        setOpenQuestions((prev) => {
+          const next = new Set(prev);
+          next.delete(questionId);
+          return next;
+        });
+      }
+    } catch {
+      alert('질문 삭제에 실패했습니다. 다시 시도해주세요.');
+    }
+  };
+
   const generateFeedback = async (questionId: number, answerId: number) => {
     setQuestions((prev) =>
       prev.map((q) =>
@@ -431,12 +449,28 @@ export function InterviewDetail() {
                         <p className="text-gray-900 font-medium">{q.content}</p>
                       )}
                     </div>
-                    {q.status === 'DONE' &&
-                      (openQuestions.has(q.questionId) ? (
-                        <ChevronDown className="w-5 h-5 text-gray-400 flex-shrink-0 ml-2" />
-                      ) : (
-                        <ChevronRight className="w-5 h-5 text-gray-400 flex-shrink-0 ml-2" />
-                      ))}
+                    <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          deleteQuestion(q.questionId);
+                        }}
+                        className="p-1 text-gray-300 hover:text-red-400 transition-colors"
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <polyline points="3 6 5 6 21 6" />
+                          <path d="M19 6l-1 14H6L5 6" />
+                          <path d="M10 11v6M14 11v6" />
+                          <path d="M9 6V4h6v2" />
+                        </svg>
+                      </button>
+                      {q.status === 'DONE' &&
+                        (openQuestions.has(q.questionId) ? (
+                          <ChevronDown className="w-5 h-5 text-gray-400" />
+                        ) : (
+                          <ChevronRight className="w-5 h-5 text-gray-400" />
+                        ))}
+                    </div>
                   </button>
 
                   {/* 질문 상세 (펼침) */}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 PR 제목
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
  - deleteQuestion(questionId) — DELETE /api/v1/questions/{questionId} 추가 (member.ts)
  - 각 질문 헤더 우측에 휴지통 아이콘 버튼 추가 (e.stopPropagation으로 토글과 분리)
  - 삭제 전 confirm으로 "관련 답변도 모두 삭제됩니다" 안내
  - 삭제 성공 시 해당 질문을 목록에서 즉시 제거, 열려있던 경우 openQuestions에서도 제거
<img width="2506" height="1242" alt="image" src="https://github.com/user-attachments/assets/667ae950-abf8-496e-8f66-d5c693c40be9" />

## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
