### PR TITLE
feat: 마이페이지 닉네임 중복 확인 API 연동

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -183,7 +183,29 @@ export type ReportListParams = {
   answerType: 'TEXT' | 'VOICE' | 'ALL';
 };
 
+export type NicknameCheckRequest = {
+  nickname: string;
+};
+
+export type NicknameCheckResult = {
+  code: string;
+};
+
 // ========== API 호출 함수 ==========
+
+/**
+ * 닉네임 중복 확인
+ * POST /api/v1/members/nickname
+ */
+export const checkNickname = async (
+  data: NicknameCheckRequest
+): Promise<ApiResponse<null>> => {
+  const response = await client.post<ApiResponse<null>>(
+    '/api/v1/members/nickname',
+    data
+  );
+  return response.data;
+};
 
 /**
  * 프로필 정보 설정 (최초 온보딩)

--- a/src/components/common/SettingsModal.tsx
+++ b/src/components/common/SettingsModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { X, Upload } from 'lucide-react';
-import { updateProfileImage } from '../../api/member';
+import { updateProfileImage, checkNickname } from '../../api/member';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -33,7 +33,7 @@ export function SettingsModal({ isOpen, onClose, currentProfile, onSave }: Setti
   const [preferredStacks, setPreferredStacks] = useState<string[]>(currentProfile.preferredStacks || []);
   const [notificationsEnabled] = useState(currentProfile.notificationsEnabled);
   const [commentNotificationsEnabled, setCommentNotificationsEnabled] = useState(currentProfile.commentNotificationsEnabled);
-  const [nicknameChecked, setNicknameChecked] = useState(false);
+  const [nicknameStatus, setNicknameStatus] = useState<'idle' | 'checking' | 'available' | 'unavailable'>('idle');
 
   const stackCategories = {
     '백엔드': ['PHP', 'Node.js', 'Nest.js', 'SpringBoot', 'Django', 'Flask', 'FastAPI', 'Ruby on Rails', 'ASP.NET', 'Go', 'Rust'],
@@ -50,13 +50,24 @@ export function SettingsModal({ isOpen, onClose, currentProfile, onSave }: Setti
     const value = e.target.value;
     if (value.length <= 10) {
       setNickname(value);
-      setNicknameChecked(false);
+      setNicknameStatus('idle');
     }
   };
 
-  const handleCheckNickname = () => {
-    // Mock duplicate check - 실제 앱에서는 API 호출이어야 함
-    setNicknameChecked(true);
+  const handleCheckNickname = async () => {
+    if (!nickname.trim()) return;
+    setNicknameStatus('checking');
+    try {
+      const response = await checkNickname({ nickname: nickname.trim() });
+      if (response.code === 'MEMBER200_7') {
+        setNicknameStatus('available');
+      } else {
+        setNicknameStatus('unavailable');
+      }
+    } catch {
+      setNicknameStatus('idle');
+      alert('닉네임 확인 중 오류가 발생했습니다. 다시 시도해주세요.');
+    }
   };
 
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -102,7 +113,7 @@ export function SettingsModal({ isOpen, onClose, currentProfile, onSave }: Setti
     );
   };
 
-  const isProfileValid = nickname.trim().length > 0 && nicknameChecked && techStack;
+  const isProfileValid = nickname.trim().length > 0 && nicknameStatus === 'available' && techStack;
 
   const handleSave = () => {
     if (isProfileValid) {
@@ -211,19 +222,24 @@ export function SettingsModal({ isOpen, onClose, currentProfile, onSave }: Setti
                   />
                   <button
                     onClick={handleCheckNickname}
-                    disabled={!nickname.trim()}
+                    disabled={!nickname.trim() || nicknameStatus === 'checking'}
                     className={`px-5 py-2.5 rounded-lg transition-colors whitespace-nowrap ${
-                      nickname.trim()
+                      nickname.trim() && nicknameStatus !== 'checking'
                         ? 'bg-sky-500 hover:bg-sky-600 text-white'
                         : 'bg-gray-200 text-gray-400 cursor-not-allowed'
                     }`}
                   >
-                    중복확인
+                    {nicknameStatus === 'checking' ? '확인 중...' : '중복확인'}
                   </button>
                 </div>
-                {nicknameChecked && (
+                {nicknameStatus === 'available' && (
                   <p className="text-sm text-green-600 mt-2">
                     ✓ 사용 가능한 닉네임입니다.
+                  </p>
+                )}
+                {nicknameStatus === 'unavailable' && (
+                  <p className="text-sm text-red-500 mt-2">
+                    ✗ 사용할 수 없는 닉네임입니다.
                   </p>
                 )}
               </div>


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 PR 제목
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
 - checkNickname(data) — POST /api/v1/members/nickname 추가 (member.ts)
  - 닉네임 입력 변경 시 상태 초기화 → 저장 버튼 비활성화
  - 중복확인 클릭 시 API 호출, MEMBER200_7이면 "사용 가능", 그 외엔 "사용 불가" 메시지 표시
  - 확인 중 버튼 비활성화 + "확인 중..." 텍스트 표시
  - 저장 버튼은 nicknameStatus === 'available'일 때만 활성화


변경 파일

  src/api/member.ts
  - checkNickname(data) — POST /api/v1/members/nickname

  src/components/common/SettingsModal.tsx
  
  닉네임 중복 확인
  - nicknameStatus 상태 추가 ('idle' | 'checking' | 'available' | 'unavailable')
  - 중복확인 버튼 클릭 시 checkNickname API 호출
  - MEMBER200_7 → "사용 가능한 닉네임입니다." (초록), 그 외 → "사용할 수 없는 닉네임입니다." (빨강)
  - 닉네임 입력 변경 시 상태 초기화, 저장 버튼은 available 상태일 때만 활성화
  - API 호출 중 버튼 비활성화 + "확인 중..." 텍스트 표시
  - 
## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
