### PR TITLE
feat: 마이페이지 회원탈퇴 API 연동

### DIFF
--- a/src/components/common/SettingsModal.tsx
+++ b/src/components/common/SettingsModal.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router';
 import { X, Upload } from 'lucide-react';
 import { updateProfileImage, checkNickname } from '../../api/member';
+import { withdraw } from '../../api/auth';
+import { useAuthStore } from '../../store/authStore';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -26,6 +29,8 @@ interface SettingsModalProps {
 type TabType = 'profile' | 'notification';
 
 export function SettingsModal({ isOpen, onClose, currentProfile, onSave }: SettingsModalProps) {
+  const navigate = useNavigate();
+  const logout = useAuthStore((s) => s.logout);
   const [activeTab, setActiveTab] = useState<TabType>('profile');
   const [nickname, setNickname] = useState(currentProfile.nickname);
   const [profileImage, setProfileImage] = useState(currentProfile.profileImage);
@@ -299,9 +304,16 @@ export function SettingsModal({ isOpen, onClose, currentProfile, onSave }: Setti
               {/* 액션 버튼 - 하단 고정 */}
               <div className="pt-6 border-t border-gray-200 mt-4 flex justify-between">
                 <button
-                  onClick={() => {
-                    if (confirm('정말로 회원 탈퇴하시겠습니까?')) {
-                      console.log('Account deletion requested');
+                  onClick={async () => {
+                    if (!confirm('정말로 회원 탈퇴하시겠습니까?\n탈퇴 후 일주일 내 재가입 시 계정 복구가 가능합니다.')) return;
+                    try {
+                      const response = await withdraw();
+                      if (response.isSuccess) {
+                        logout();
+                        navigate('/login');
+                      }
+                    } catch {
+                      alert('회원 탈퇴 중 오류가 발생했습니다. 다시 시도해주세요.');
                     }
                   }}
                   className="w-32 py-2.5 border border-red-300 text-red-600 hover:bg-red-50 rounded-lg transition-colors"


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 PR 제목
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
변경 파일


  src/components/common/SettingsModal.tsx
  

  회원 탈퇴
  - 회원탈퇴 버튼 클릭 시 confirm (소프트 딜리트 안내 포함)
  - DELETE /api/v1/auth/withdraw 호출
  - 성공 시 authStore.logout()으로 토큰 제거 후 /login으로 이동
<img width="1588" height="582" alt="image" src="https://github.com/user-attachments/assets/db121d75-71a6-4fdf-87f2-8f3454f572cc" />

## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
