### PR TITLE
feat: 요약본 상세 조회 API 응답 변경사항 반영

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -128,10 +128,18 @@ export type Features = {
   feature5: FeatureDetail;
 };
 
+export type ImprovementDetail = {
+  title: string;
+  files: string[] | null;
+  currentStatus: string;
+  example: string;
+  actionPlan: string;
+};
+
 export type Improvements = {
-  improvement1: FeatureDetail;
-  improvement2: FeatureDetail;
-  improvement3: FeatureDetail;
+  improvement1: ImprovementDetail;
+  improvement2: ImprovementDetail;
+  improvement3: ImprovementDetail;
 };
 
 export type Content = {

--- a/src/pages/Analysis/AnalyticsDetail.tsx
+++ b/src/pages/Analysis/AnalyticsDetail.tsx
@@ -303,7 +303,7 @@ export function AnalyticsDetail() {
                         <p className="text-sm text-sky-600">내 커밋</p>
                       </div>
                       <div className="bg-green-50 p-4 rounded-lg text-center">
-                        <p className="text-2xl font-bold text-green-900">{analysisData.content.content.commitStats.myCommitRate}%</p>
+                        <p className="text-2xl font-bold text-green-900">{(analysisData.content.content.commitStats.myCommitRate * 100).toFixed(1)}%</p>
                         <p className="text-sm text-green-600">기여도</p>
                       </div>
                     </div>
@@ -378,7 +378,24 @@ export function AnalyticsDetail() {
                               </div>
                             </div>
                           )}
-                          <p className="text-sm text-gray-700">{improvement.content}</p>
+                          {improvement.currentStatus && (
+                            <div className="mb-2">
+                              <p className="text-sm font-medium text-gray-700 mb-1">현재 상태:</p>
+                              <p className="text-sm text-gray-700">{improvement.currentStatus}</p>
+                            </div>
+                          )}
+                          {improvement.example && (
+                            <div className="mb-2">
+                              <p className="text-sm font-medium text-gray-700 mb-1">예시:</p>
+                              <p className="text-sm text-gray-700">{improvement.example}</p>
+                            </div>
+                          )}
+                          {improvement.actionPlan && (
+                            <div>
+                              <p className="text-sm font-medium text-gray-700 mb-1">개선 계획:</p>
+                              <p className="text-sm text-gray-700">{improvement.actionPlan}</p>
+                            </div>
+                          )}
                         </div>
                       ))}
                     </div>


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌feat: 요약본 상세 조회 API 응답 변경사항 반영
<!-- 간단하게 기능/버그 수정 요약  -->
<img width="2404" height="1238" alt="image" src="https://github.com/user-attachments/assets/008f2307-d54b-40d2-8fe4-cdf32d70b3b3" />

## 📝 작업 내용
백엔드 `GET /api/v1/reports/{reportId}` 응답 변경에 따른 업데이트입니다.

  ### 변경 사항

  **`src/api/member.ts`**
  - `ImprovementDetail` 타입 신규 추가
    - 기존: `FeatureDetail` 재사용 (`content: string`)
    - 변경: `currentStatus`, `example`, `actionPlan` 필드로 구성된 별도 타입 
  - `Improvements` 타입의 각 항목을 `ImprovementDetail`로 교체

  **`src/pages/Analysis/AnalyticsDetail.tsx`**
  - `myCommitRate` 표시 방식 수정
    - 기존: 정수값 그대로 표시 (e.g. `14%`)
    - 변경: 소수값 × 100 후 소수점 1자리 표시 (e.g. `0.3125` → `31.3%`)      
  - 개선사항 카드 렌더링 변경
    - 기존: `content` 단일 텍스트
    - 변경: **현재 상태 / 예시 / 개선 계획** 3개 섹션으로 분리 표시

## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?
 
<!--src/api/member.ts
  - Improvements 타입의 각 항목을 기존
  FeatureDetail(content 필드) 대신 새 ImprovementDetail  
  타입(currentStatus, example, actionPlan 필드)으로 변경 

  src/pages/Analysis/AnalyticsDetail.tsx
  - myCommitRate 표시: 0.3125 → × 100해서 31.3%로 표시   
  (toFixed(1))
  - 개선사항 렌더링: content 단일 텍스트 대신 현재 상태 /
  예시 / 개선 계획 3개 섹션으로 표시-->
## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->

