### PR TITLE
fix: 요약본 생성 중 로딩 페이지 무한 루프 수정

### DIFF
--- a/src/pages/Analysis/AnalyticsLoading.tsx
+++ b/src/pages/Analysis/AnalyticsLoading.tsx
@@ -18,7 +18,7 @@ export function AnalyticsLoading() {
 
       try {
         const response = await getReportDetail(Number(reportId));
-        if (response.isSuccess) {
+        if (response.isSuccess && response.result) {
           // 분석본이 준비되면 상세 페이지로 이동
           navigate(`/analytics/detail/${reportId}`);
         } else {


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 fix: 요약본 생성 중 로딩 페이지 무한 루프 수정

<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용

 원인
  백엔드가 요약본 생성 중일 때 아래와 같은 응답을 반환함.

  { "isSuccess": true, "code": "REPORT200_6", "message": "요약본 생성      
  중입니다." }

  AnalyticsLoading에서 response.isSuccess만 체크하고 있어, result가 없는   
  생성 중 응답도 완료로 판단해 /analytics/detail/:id로 이동함.       
  AnalyticsDetail은 result가 없으면 다시 /analytics/loading으로 보내, 두   
  페이지가 무한히 왔다 갔다 하는 루프가 발생함.

  수정

  src/pages/Analysis/AnalyticsLoading.tsx
  - response.isSuccess → response.isSuccess && response.result
- result가 실제로 존재할 때만 상세 페이지로 이동하도록 변경
## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
