### PR TITLE
fix: 프로필 수정 시 사이드바·콘텐츠 영역 즉시 반영

### DIFF
--- a/src/components/common/ProfileCard.tsx
+++ b/src/components/common/ProfileCard.tsx
@@ -37,17 +37,19 @@ export function ProfileCard({
         alert('희망분야 값이 올바르지 않습니다.');
         return;
       }
-      
+
       const techStackList = stacksToEnumList(data.preferredStacks);
-      
+
       const response = await updateProfile({
         nickname: data.nickname,
         jobType,
         techStackList,
       });
-      
+
       if (response.isSuccess) {
         setProfileData(data);
+        localStorage.setItem('myNickname', data.nickname);
+        window.dispatchEvent(new CustomEvent('profile-updated', { detail: { name: data.nickname } }));
         alert('프로필이 성공적으로 수정되었습니다.');
       } else {
         alert(response.message || '프로필 수정에 실패했습니다.');
@@ -57,6 +59,10 @@ export function ProfileCard({
       alert(errorMessage);
       console.error('프로필 수정 실패:', error);
     }
+  };
+
+  const handleImageUpdate = (imageUrl: string) => {
+    setProfileData((prev) => ({ ...prev, profileImage: imageUrl }));
   };
 
   return (
@@ -130,6 +136,7 @@ export function ProfileCard({
         onClose={() => setIsSettingsOpen(false)}
         currentProfile={profileData}
         onSave={handleSaveSettings}
+        onImageUpdate={handleImageUpdate}
       />
     </div>
   );

--- a/src/components/common/SettingsModal.tsx
+++ b/src/components/common/SettingsModal.tsx
@@ -24,11 +24,12 @@ interface SettingsModalProps {
     notificationsEnabled: boolean;
     commentNotificationsEnabled: boolean;
   }) => void;
+  onImageUpdate?: (imageUrl: string) => void;
 }
 
 type TabType = 'profile' | 'notification';
 
-export function SettingsModal({ isOpen, onClose, currentProfile, onSave }: SettingsModalProps) {
+export function SettingsModal({ isOpen, onClose, currentProfile, onSave, onImageUpdate }: SettingsModalProps) {
   const navigate = useNavigate();
   const logout = useAuthStore((s) => s.logout);
   const [activeTab, setActiveTab] = useState<TabType>('profile');
@@ -95,7 +96,10 @@ export function SettingsModal({ isOpen, onClose, currentProfile, onSave }: Setti
           // 성공 시 미리보기 업데이트
           const reader = new FileReader();
           reader.onloadend = () => {
-            setProfileImage(reader.result as string);
+            const dataUrl = reader.result as string;
+            setProfileImage(dataUrl);
+            onImageUpdate?.(dataUrl);
+            window.dispatchEvent(new CustomEvent('profile-updated', { detail: { avatar: dataUrl } }));
           };
           reader.readAsDataURL(file);
           alert('프로필 사진이 성공적으로 변경되었습니다.');

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -60,6 +60,19 @@ export function Layout() {
     fetchUserProfile();
   }, []);
 
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { name, avatar } = (e as CustomEvent<{ name?: string; avatar?: string }>).detail;
+      setUserProfile((prev) => ({
+        ...prev,
+        ...(name !== undefined && { name }),
+        ...(avatar !== undefined && { avatar }),
+      }));
+    };
+    window.addEventListener('profile-updated', handler);
+    return () => window.removeEventListener('profile-updated', handler);
+  }, []);
+
   return (
     <div className="min-h-screen bg-sky-50">
       <AppSidebar


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 PR 제목
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
fix: 프로필 수정 시 사이드바·콘텐츠 영역 즉시 반영

닉네임 저장 후 사이드바가 새로고침 전까지 갱신되지 않던 문제,
프로필 이미지 변경 시 콘텐츠 영역과 사이드바 모두 반영되지 않던 문제 수정.

- SettingsModal: 이미지 업로드 성공 시 onImageUpdate 콜백 호출 및
  profile-updated CustomEvent 발행
- ProfileCard: handleImageUpdate 추가로 이미지 변경 즉시 반영,
  닉네임 저장 성공 시 profile-updated 이벤트 발행 및 localStorage 동기화
- Layout: profile-updated 이벤트 구독으로 사이드바 userProfile 즉시 업데이트

---
PR 설명:

## Summary

- 닉네임 변경 저장 후 사이드바가 새로고침 없이 즉시 반영되지 않던 버그 수정
- 프로필 이미지 변경 시 콘텐츠 영역(ProfileCard)과 사이드바 모두 즉시 반영되지 않던 버그 수정

## Changes

`window`의 `profile-updated` CustomEvent를 통해 컴포넌트 간 상태를 동기화합니다.

| 파일 | 변경 내용 |
|------|-----------|
| `SettingsModal.tsx` | 이미지 업로드 성공 시 `onImageUpdate` 콜백 호출 + `profile-updated` 이벤트 발행 |
| `ProfileCard.tsx` | `handleImageUpdate` 추가로 이미지 변경 즉시 반영, 닉네임 저장 시 이벤트 발행 및 `localStorage.myNickname` 동기화 |
| `Layout.tsx` | `profile-updated` 이벤트 구독하여 사이드바 `userProfile` 즉시 업데이트 |

## Test Plan

- [ ] 닉네임 중복확인 후 저장 → 콘텐츠 영역과 사이드바 닉네임 동시 변경 확인
- [ ] 프로필 이미지 변경 → 모달 미리보기, 콘텐츠 영역, 사이드바 아바타 동시 변경 확인
- [ ] 새로고침 없이 위 동작이 모두 반영되는지 확인
## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
