### PR TITLE
fix: 마이페이지 프로필 설정 모달 선호스택 미표시 및 저장 버튼 비활성화 문제 수정

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -70,7 +70,7 @@ export type MyProfile = {
   profileImage: string;
   jobType: JobType;
   githubId: string;
-  techStack: TechStack[];
+  techStackList: TechStack[];
 };
 
 export type ProfileImageResult = {

--- a/src/components/common/ProfileCard.tsx
+++ b/src/components/common/ProfileCard.tsx
@@ -12,6 +12,7 @@ interface ProfileCardProps {
   nickname: string;
   githubId: string;
   techStack: string;
+  preferredStacks?: string[];
 }
 
 export function ProfileCard({
@@ -19,13 +20,14 @@ export function ProfileCard({
   nickname,
   githubId,
   techStack,
+  preferredStacks = [],
 }: ProfileCardProps) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [profileData, setProfileData] = useState({
     nickname,
     profileImage,
     techStack,
-    preferredStacks: [] as string[],
+    preferredStacks,
     notificationsEnabled: true,
     commentNotificationsEnabled: true,
   });

--- a/src/components/common/SettingsModal.tsx
+++ b/src/components/common/SettingsModal.tsx
@@ -122,7 +122,11 @@ export function SettingsModal({ isOpen, onClose, currentProfile, onSave, onImage
     );
   };
 
-  const isProfileValid = nickname.trim().length > 0 && nicknameStatus === 'available' && techStack;
+  const nicknameUnchanged = nickname.trim() === currentProfile.nickname.trim();
+  const isProfileValid =
+    nickname.trim().length > 0 &&
+    techStack &&
+    (nicknameUnchanged || nicknameStatus === 'available');
 
   const handleSave = () => {
     if (isProfileValid) {

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -9,6 +9,7 @@ import {
   getRepositories,
   type GitTurlHistory,
 } from '../../api/member';
+import { enumListToStacks } from '../../utils/stackMapping';
 import defaultProfile from '../../assets/img/img_profile.svg';
 
 export function MyPage() {
@@ -17,11 +18,13 @@ export function MyPage() {
     nickname: string;
     githubId: string;
     techStack: 'frontend' | 'backend' | 'ai';
+    preferredStacks: string[];
   }>({
     profileImage: defaultProfile,
     nickname: '로딩 중...',
     githubId: '',
     techStack: 'backend',
+    preferredStacks: [],
   });
 
   const [loading, setLoading] = useState(true);
@@ -76,6 +79,7 @@ export function MyPage() {
           nickname: profile?.nickname || '사용자',
           githubId: profile?.githubId || '',
           techStack,
+          preferredStacks: enumListToStacks(profile?.techStackList ?? []),
         });
 
         setLoading(false);
@@ -130,6 +134,7 @@ export function MyPage() {
               nickname={profileData.nickname}
               githubId={profileData.githubId}
               techStack={profileData.techStack}
+              preferredStacks={profileData.preferredStacks}
             />
 
             {/* 깃털 히스토리 */}

--- a/src/utils/stackMapping.ts
+++ b/src/utils/stackMapping.ts
@@ -75,3 +75,14 @@ export const stacksToEnumList = (stacks: string[]): TechStack[] => {
   // 중복 제거 (ETC가 여러 개일 수 있음)
   return Array.from(new Set(enums));
 };
+
+// API enum → 표시명 역방향 변환
+const enumToStackMap: Partial<Record<TechStack, string>> = Object.fromEntries(
+  Object.entries(stackToEnum).map(([display, enumVal]) => [enumVal, display])
+) as Partial<Record<TechStack, string>>;
+
+export const enumToStack = (enumVal: TechStack): string =>
+  enumToStackMap[enumVal] ?? enumVal;
+
+export const enumListToStacks = (enums: TechStack[]): string[] =>
+  enums.map(enumToStack);


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 PR 제목
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
fix: 설정 모달 선호스택 미표시 및 저장 버튼 비활성화 문제 수정

- MyProfile 타입 필드명 techStack → techStackList (API 응답과 불일치 수정)
- stackMapping에 enumToStack / enumListToStacks 역방향 변환 함수 추가
- MyPage에서 techStackList를 표시명으로 변환해 ProfileCard로 전달
- ProfileCard에 preferredStacks prop 추가, 설정 모달 초기값으로 사용
- SettingsModal 저장 버튼 활성화 조건 수정:
  닉네임 미변경 시 중복확인 없이도 희망분야·선호스택 변경 저장 가능

---
PR 설명:

## Summary

- 설정 모달에서 희망분야·선호스택을 수정해도 저장 버튼이 활성화되지 않던 버그 수정
- 설정 모달을 열었을 때 기존에 저장된 선호스택이 표시되지 않던 버그 수정

## Root Cause

| 문제 | 원인 |
|------|------|
| 선호스택 미표시 | `MyProfile` 타입의 필드명이 `techStack`이었으나 API는 `techStackList`로 응답, 데이터가 전달되지 않음 |
| 선호스택 미표시 | `MyPage`가 API에서 받은 `techStackList`를 `ProfileCard`에 전달하지 않아 항상 빈 배열로 초기화됨 |
| 저장 버튼 비활성화 | `isProfileValid` 조건이 `nicknameStatus === 'available'`을 항상 요구해, 닉네임을 바꾸지 않아도 중복확인을 해야만 저장 가능했음 |

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `api/member.ts` | `MyProfile.techStack` → `techStackList` (API 필드명 일치) |
| `utils/stackMapping.ts` | `enumToStack`, `enumListToStacks` 역방향 변환 함수 추가 |
| `pages/MyPage/MyPage.tsx` | `techStackList`를 표시명으로 변환해 `preferredStacks`로 전달 |
| `components/common/ProfileCard.tsx` | `preferredStacks` prop 추가, 초기값으로 사용 |
| `components/common/SettingsModal.tsx` | 닉네임 미변경 시 중복확인 없이 저장 가능하도록 조건 수정 |

## Test Plan

- [ ] 설정 모달 열었을 때 기존 선호스택 버튼 선택 상태로 표시되는지 확인
- [ ] 닉네임 그대로 두고 희망분야만 바꿨을 때 저장 버튼 활성화 확인
- [ ] 닉네임 그대로 두고 선호스택만 바꿨을 때 저장 버튼 활성화 확인
- [ ] 닉네임 변경 시에는 여전히 중복확인 후에만 저장 가능한지 확인

## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
