### PR TITLE
fix: 텍스트면접 답변 삭제 후 화면 미갱신 버그 수정

### DIFF
--- a/src/pages/Interview/InterviewDetail.tsx
+++ b/src/pages/Interview/InterviewDetail.tsx
@@ -231,7 +231,13 @@ export function InterviewDetail() {
     try {
       const response = await deleteAnswerApi(answerId);
       if (response.isSuccess) {
-        fetchAnswersForQuestion(questionId);
+        setQuestions((prev) =>
+          prev.map((q) =>
+            q.questionId === questionId
+              ? { ...q, answers: q.answers.filter((a) => a.answerId !== answerId) }
+              : q
+          )
+        );
       }
     } catch {
       alert('답변 삭제에 실패했습니다. 다시 시도해주세요.');


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 PR 제목
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
fix: 텍스트 답변 삭제 후 화면 미갱신 버그 수정

답변 삭제 성공 후 fetchAnswersForQuestion을 호출하면 백엔드가
QUESTION404_1을 반환해 예외가 발생하고, catch 블록이 isLoadingAnswers만
리셋할 뿐 answers 목록을 갱신하지 않아 삭제된 답변이 화면에 잔류하던 문제 수정.
재조회 대신 삭제 성공 시 로컬 state에서 해당 answerId를 직접 필터링해 제거.

---
PR 설명:

## Summary

- AI 피드백이 완료된 답변을 삭제했을 때 화면에서 즉시 사라지지 않던 버그 수정
- 페이지를 나갔다 돌아와야 반영되던 문제 해결

## Root Cause

답변 삭제(`DELETE /api/v1/answers/{answerId}`) 성공 후 `fetchAnswersForQuestion`으로
답변 목록을 재조회(`GET /api/v1/questions/{questionId}/answers`)하는데,
백엔드가 `QUESTION404_1`을 반환해 예외가 발생함.

catch 블록이 `isLoadingAnswers: false`만 리셋할 뿐 answers 배열을 갱신하지 않아
삭제된 답변이 로컬 state에 그대로 잔류 → 화면에 계속 표시됨.

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `pages/Interview/InterviewDetail.tsx` | 답변 삭제 성공 시 `fetchAnswersForQuestion` 호출 대신 로컬 state에서 `answerId` 직접 필터링 제거 |

## Test Plan

- [ ] AI 피드백 없는 답변 삭제 시 즉시 화면에서 사라지는지 확인
- [ ] AI 피드백 있는 답변 삭제 시 즉시 화면에서 사라지는지 확인
- [ ] 삭제 후 페이지 재진입 시 동일하게 삭제된 상태인지 확인

## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
