### PR TITLE
fix: 게시글 이미지 유무 조건부 렌더링

### DIFF
--- a/src/pages/Community/CommunityList.tsx
+++ b/src/pages/Community/CommunityList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import {
   Search,
   Plus,
@@ -110,9 +110,29 @@ function stripHtml(html: string): string {
     .trim();
 }
 
+// HTML 본문에서 첫 번째 <img> src 추출. imageUrl 이 비어있을 때 fallback.
+function extractFirstImage(html: string): string | null {
+  if (!html) return null;
+  const m = html.match(/<img[^>]+src=["']([^"']+)["']/i);
+  return m ? m[1] : null;
+}
+
+// 쿼리 파라미터 → 탭 매핑. 잘못된 값이면 기본 study.
+const tabFromParam = (raw: string | null): TabType => {
+  if (raw === 'project' || raw === 'free' || raw === 'study') return raw;
+  return 'study';
+};
+
 export function CommunityList() {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<TabType>('study');
+  const [searchParams] = useSearchParams();
+  const tabParam = searchParams.get('tab');
+  const [activeTab, setActiveTab] = useState<TabType>(tabFromParam(tabParam));
+
+  // URL ?tab 이 바뀌면 activeTab 동기화 (이미 페이지에 있을 때 외부 링크로 이동 시).
+  useEffect(() => {
+    setActiveTab(tabFromParam(tabParam));
+  }, [tabParam]);
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1); // UI: 1-indexed, API: 0-indexed
 
@@ -727,24 +747,28 @@ function PostRow({
         </div>
       </div>
 
-      <div
-        style={{
-          width: 130,
-          height: 92,
-          background: post.imageUrl ? 'transparent' : '#E5E7EB',
-          borderRadius: 10,
-          flexShrink: 0,
-          overflow: 'hidden',
-        }}
-      >
-        {post.imageUrl && (
-          <img
-            src={post.imageUrl}
-            alt=""
-            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
-          />
-        )}
-      </div>
+      {(() => {
+        // imageUrl 우선, 없으면 content 안 첫 <img>
+        const preview = post.imageUrl ?? extractFirstImage(post.content);
+        if (!preview) return null;
+        return (
+          <div
+            style={{
+              width: 130,
+              height: 92,
+              borderRadius: 10,
+              flexShrink: 0,
+              overflow: 'hidden',
+            }}
+          >
+            <img
+              src={preview}
+              alt=""
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+            />
+          </div>
+        );
+      })()}
     </div>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 PR 제목
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
- 게시글 회색 임시 처리 -> 삭제
- 게시글 이미지 있을 시 - 게시글에 등록된 첫번째 이미지만 미리보기
- 게시글 이미지 없을 시 - 흰색 배경

## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
