### PR TITLE
feat: 요약본 PDF 저장 기능 구현

### DIFF
--- a/src/components/common/AppSidebar.tsx
+++ b/src/components/common/AppSidebar.tsx
@@ -86,7 +86,7 @@ export function AppSidebar({
   }, [showInterviewPopup]);
 
   return (
-    <aside className="fixed left-0 top-0 h-screen w-64 bg-white border-r border-sky-200 flex flex-col shadow-sm z-50">
+    <aside className="fixed left-0 top-0 h-screen w-64 bg-white border-r border-sky-200 flex flex-col shadow-sm z-50 print:hidden">
       {/* 로고 섹션 */}
       <div className="p-6 border-b border-sky-100">
         <div className="flex items-center gap-3">

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
 
 @import './styles/tailwind.css';
 @import './styles/theme.css';
+
+@media print {
+  main {
+    margin-left: 0 !important;
+  }
+}

--- a/src/pages/Analysis/AnalyticsDetail.tsx
+++ b/src/pages/Analysis/AnalyticsDetail.tsx
@@ -85,7 +85,7 @@ export function AnalyticsDetail() {
   };
 
   const handleDownloadPDF = () => {
-    alert('PDF 다운로드 기능이 실행됩니다.');
+    window.print();
   };
 
   const handleCreateQuestions = async () => {
@@ -156,7 +156,7 @@ export function AnalyticsDetail() {
     <div className="min-h-screen p-8 bg-[#F0F9FF]">
       <div className="max-w-6xl mx-auto">
         {/* 네비게이션 경로 */}
-        <div className="flex items-center gap-2 mb-8 text-sm">
+        <div className="flex items-center gap-2 mb-8 text-sm print:hidden">
           <Link
             to="/analytics"
             className="text-sky-600 hover:text-sky-700 hover:underline transition-colors"
@@ -222,7 +222,7 @@ export function AnalyticsDetail() {
               </p>
             </div>
 
-            <div className="flex flex-col items-end gap-3">
+            <div className="flex flex-col items-end gap-3 print:hidden">
               {/* 공개/비공개 토글 스위치 */}
               <div className="flex items-center gap-3">
                 <button
@@ -255,7 +255,7 @@ export function AnalyticsDetail() {
 
           {/* 분석 내용 */}
           <div className="prose max-w-none mb-8">
-            <div className="bg-gradient-to-br from-gray-50 to-gray-100 rounded-xl p-8 border border-gray-200 min-h-[600px] max-h-[800px] overflow-y-auto shadow-inner">
+            <div className="bg-gradient-to-br from-gray-50 to-gray-100 rounded-xl p-8 border border-gray-200 min-h-[600px] max-h-[800px] overflow-y-auto shadow-inner print:max-h-none print:overflow-visible">
               <h2 className="text-xl text-gray-900 mb-4 font-semibold">
                 {analysisData.repoName} 분석 리포트
               </h2>
@@ -410,7 +410,7 @@ export function AnalyticsDetail() {
           </div>
 
           {/* 면접 질문 생성 */}
-          <div className="flex flex-col items-center gap-4 pt-6 border-t border-gray-200">
+          <div className="flex flex-col items-center gap-4 pt-6 border-t border-gray-200 print:hidden">
             {!showQuestionForm ? (
               <button
                 onClick={() => setShowQuestionForm(true)}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 PR 제목
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
feat: 요약본 PDF 저장 기능 구현

  브라우저 인쇄 기능을 활용해 요약본을 PDF로 저장할 수 있도록 구현.
  인쇄 시 사이드바·버튼·면접 질문 영역을 숨기고 리포트 내용만 출력.

  ---

  ## 변경 사항

  - `AnalyticsDetail` 페이지의 "pdf로 저장" 버튼 클릭 시 `window.print()` 호출
  - 인쇄 시 불필요한 UI 숨김 처리
    - 사이드바 (`print:hidden`)
    - 브레드크럼 네비게이션 (`print:hidden`)
    - 공개/비공개 토글, PDF 버튼 (`print:hidden`)
    - 면접 질문 생성 영역 (`print:hidden`)
  - 리포트 내용 영역: 인쇄 시 높이 제한·스크롤 해제 (`print:max-h-none print:overflow-visible`)
  - `@media print`로 사이드바 여백 제거

  ## 사용 방법

  "pdf로 저장" 버튼 클릭 → 브라우저 인쇄 다이얼로그에서 대상을 **PDF로 저장** 선택

## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
